### PR TITLE
HtmlToXamlDemo - Html tags to lowercase and fixed an issue with umlauts and special characters

### DIFF
--- a/Sample Applications/HtmlToXamlDemo/HtmlEncodedTextWriter.cs
+++ b/Sample Applications/HtmlToXamlDemo/HtmlEncodedTextWriter.cs
@@ -10,21 +10,15 @@ namespace HtmlToXamlDemo
 {
     public class HtmlEncodedTextWriter : XmlTextWriter
     {
-        private readonly XmlTextWriter _textWriter;
-
-        public HtmlEncodedTextWriter(TextWriter w) : base(w)
-        {
-            _textWriter = this;
-        }
+        public HtmlEncodedTextWriter(TextWriter w) : base(w) { }
 
         #region Overrides of XmlTextWriter
-
 
         /// <inheritdoc />
         public override void WriteString(string text)
         {
             text = WebUtility.HtmlEncode(text);
-            _textWriter.WriteRaw(text);
+            WriteRaw(text);
         }
 
         #endregion

--- a/Sample Applications/HtmlToXamlDemo/HtmlEncodedTextWriter.cs
+++ b/Sample Applications/HtmlToXamlDemo/HtmlEncodedTextWriter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Xml;
+
+namespace HtmlToXamlDemo
+{
+    public class HtmlEncodedTextWriter : XmlTextWriter
+    {
+        private readonly XmlTextWriter _textWriter;
+
+        public HtmlEncodedTextWriter(TextWriter w) : base(w)
+        {
+            _textWriter = this;
+        }
+
+        #region Overrides of XmlTextWriter
+
+
+        /// <inheritdoc />
+        public override void WriteString(string text)
+        {
+            text = WebUtility.HtmlEncode(text);
+            _textWriter.WriteRaw(text);
+        }
+
+        #endregion
+    }
+}

--- a/Sample Applications/HtmlToXamlDemo/HtmlFromXamlConverter.cs
+++ b/Sample Applications/HtmlToXamlDemo/HtmlFromXamlConverter.cs
@@ -43,7 +43,7 @@ namespace HtmlToXamlDemo
             xamlReader = new XmlTextReader(new StringReader(xamlString));
 
             htmlStringBuilder = new StringBuilder(100);
-            htmlWriter = new XmlTextWriter(new StringWriter(htmlStringBuilder));
+            htmlWriter = new HtmlEncodedTextWriter(new StringWriter(htmlStringBuilder));
 
             if (!WriteFlowDocument(xamlReader, htmlWriter))
             {

--- a/Sample Applications/HtmlToXamlDemo/HtmlFromXamlConverter.cs
+++ b/Sample Applications/HtmlToXamlDemo/HtmlFromXamlConverter.cs
@@ -92,8 +92,8 @@ namespace HtmlToXamlDemo
             // on every element level (it will be re-initialized on every level).
             var inlineStyle = new StringBuilder();
 
-            htmlWriter.WriteStartElement("HTML");
-            htmlWriter.WriteStartElement("BODY");
+            htmlWriter.WriteStartElement("html");
+            htmlWriter.WriteStartElement("body");
 
             WriteFormattingProperties(xamlReader, htmlWriter, inlineStyle);
 
@@ -221,10 +221,10 @@ namespace HtmlToXamlDemo
                         css = "width:" + xamlReader.Value + ";";
                         break;
                     case "ColumnSpan":
-                        htmlWriter.WriteAttributeString("COLSPAN", xamlReader.Value);
+                        htmlWriter.WriteAttributeString("colspan", xamlReader.Value);
                         break;
                     case "RowSpan":
-                        htmlWriter.WriteAttributeString("ROWSPAN", xamlReader.Value);
+                        htmlWriter.WriteAttributeString("rowspan", xamlReader.Value);
                         break;
                 }
 
@@ -338,7 +338,7 @@ namespace HtmlToXamlDemo
                                 if (htmlWriter != null && !elementContentStarted && inlineStyle.Length > 0)
                                 {
                                     // Output STYLE attribute and clear inlineStyle buffer.
-                                    htmlWriter.WriteAttributeString("STYLE", inlineStyle.ToString());
+                                    htmlWriter.WriteAttributeString("style", inlineStyle.ToString());
                                     inlineStyle.Remove(0, inlineStyle.Length);
                                 }
                                 elementContentStarted = true;
@@ -352,7 +352,7 @@ namespace HtmlToXamlDemo
                             {
                                 if (!elementContentStarted && inlineStyle.Length > 0)
                                 {
-                                    htmlWriter.WriteAttributeString("STYLE", inlineStyle.ToString());
+                                    htmlWriter.WriteAttributeString("style", inlineStyle.ToString());
                                 }
                                 htmlWriter.WriteComment(xamlReader.Value);
                             }
@@ -365,7 +365,7 @@ namespace HtmlToXamlDemo
                             {
                                 if (!elementContentStarted && inlineStyle.Length > 0)
                                 {
-                                    htmlWriter.WriteAttributeString("STYLE", inlineStyle.ToString());
+                                    htmlWriter.WriteAttributeString("style", inlineStyle.ToString());
                                 }
                                 htmlWriter.WriteString(xamlReader.Value);
                             }
@@ -432,40 +432,40 @@ namespace HtmlToXamlDemo
                 {
                     case "Run":
                     case "Span":
-                        htmlElementName = "SPAN";
+                        htmlElementName = "span";
                         break;
                     case "InlineUIContainer":
-                        htmlElementName = "SPAN";
+                        htmlElementName = "span";
                         break;
                     case "Bold":
-                        htmlElementName = "B";
+                        htmlElementName = "b";
                         break;
                     case "Italic":
-                        htmlElementName = "I";
+                        htmlElementName = "i";
                         break;
                     case "Paragraph":
-                        htmlElementName = "P";
+                        htmlElementName = "p";
                         break;
                     case "BlockUIContainer":
-                        htmlElementName = "DIV";
+                        htmlElementName = "div";
                         break;
                     case "Section":
-                        htmlElementName = "DIV";
+                        htmlElementName = "div";
                         break;
                     case "Table":
-                        htmlElementName = "TABLE";
+                        htmlElementName = "table";
                         break;
                     case "TableColumn":
-                        htmlElementName = "COL";
+                        htmlElementName = "col";
                         break;
                     case "TableRowGroup":
-                        htmlElementName = "TBODY";
+                        htmlElementName = "tbody";
                         break;
                     case "TableRow":
-                        htmlElementName = "TR";
+                        htmlElementName = "tr";
                         break;
                     case "TableCell":
-                        htmlElementName = "TD";
+                        htmlElementName = "td";
                         break;
                     case "List":
                         var marker = xamlReader.GetAttribute("MarkerStyle");
@@ -473,15 +473,15 @@ namespace HtmlToXamlDemo
                             marker == "Square" ||
                             marker == "Box")
                         {
-                            htmlElementName = "UL";
+                            htmlElementName = "ul";
                         }
                         else
                         {
-                            htmlElementName = "OL";
+                            htmlElementName = "ol";
                         }
                         break;
                     case "ListItem":
-                        htmlElementName = "LI";
+                        htmlElementName = "li";
                         break;
                     default:
                         htmlElementName = null; // Ignore the element

--- a/Sample Applications/HtmlToXamlDemo/HtmlToXamlDemo.csproj
+++ b/Sample Applications/HtmlToXamlDemo/HtmlToXamlDemo.csproj
@@ -65,6 +65,7 @@
     </Compile>
     <Compile Include="CssStylesheet.cs" />
     <Compile Include="HtmlCSSParser.cs" />
+    <Compile Include="HtmlEncodedTextWriter.cs" />
     <Compile Include="HtmlFromXamlConverter.cs" />
     <Compile Include="HtmlLexicalAnalyzer.cs" />
     <Compile Include="HtmlParser.cs" />


### PR DESCRIPTION
HtmlToXamlDemo: Changed the html tags of the converter from uppercase to lowercase to match the current html coding guidlines. (https://www.w3schools.com/html/html5_syntax.asp)