### PR TITLE
Use safe data formats casting

### DIFF
--- a/Drag and Drop/DragDropOpenTextFile/MainWindow.cs
+++ b/Drag and Drop/DragDropOpenTextFile/MainWindow.cs
@@ -68,7 +68,7 @@ namespace DragDropOpenTextFile
             {
                 var fileNames = args.Data.GetData(DataFormats.FileDrop, true) as string[];
                 // Check fo a single file or folder.
-                if (fileNames.Length == 1)
+                if (fileNames?.Length is 1)
                 {
                     // Check for a file (a directory will return false).
                     if (File.Exists(fileNames[0]))

--- a/Drag and Drop/DragDropOpenTextFile/MainWindow.cs
+++ b/Drag and Drop/DragDropOpenTextFile/MainWindow.cs
@@ -67,7 +67,7 @@ namespace DragDropOpenTextFile
             if (args.Data.GetDataPresent(DataFormats.FileDrop, true))
             {
                 var fileNames = args.Data.GetData(DataFormats.FileDrop, true) as string[];
-                // Check fo a single file or folder.
+                // Check for a single file or folder.
                 if (fileNames?.Length is 1)
                 {
                     // Check for a file (a directory will return false).


### PR DESCRIPTION
`as` may returns null so we should check `fileNames` variable for null or there may be an exception during the runtime. If the fileNames will never be `null`, it's recommended to use `(string[])args.Data.GetData(DataFormats.FileDrop, true)` for never null casting.