### PR TITLE
Removed compat flag sample

### DIFF
--- a/Compatibility/App.config
+++ b/Compatibility/App.config
@@ -62,14 +62,6 @@ The values shown below are the defaults for the respective switch.
     <!--https://docs.microsoft.com/en-us/dotnet/api/system.windows.frameworkcompatibilitypreferences.shouldthrowoncopyorcutfailure?view=netframework-4.8#System_Windows_FrameworkCompatibilityPreferences_ShouldThrowOnCopyOrCutFailure-->
     <!--<add key="ShouldThrowOnCopyOrCutFailure" value="false"/>-->
     
-    <!-- 
-      Possible values are:
-        - Throw (.NET 4.0 behavior)
-        - Allow (default .NET 4.5+, .NET core behavior)
-        - Disallow
-    -->
-    <!--<add key="HandleTwoWayBindingToPropertyWithNonPublicSetter" value="Allow"/>-->
-    
     <!--There is a bug in the Windows desktop window manager which can cause
     incorrect z-order for windows when several conditions are all met:
     (a) windows are parented/owned across different threads or processes


### PR DESCRIPTION
The `HandleTwoWayBindingToPropertyWithNonPublicSetter` compatibility switch no longer exists in the WPF codebase after [this change](https://github.com/dotnet/wpf/pull/1502) was merged. Removing out of date sample.