### PR TITLE
Fix the sample app for databinding

### DIFF
--- a/Sample Applications/DataBindingDemo/AddProductWindow.xaml
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:DataBindingDemo"
         mc:Ignorable="d"
-        Title="AddProductWindow" Height="300" Width="300">
+        Title="Add Product Listing" SizeToContent="WidthAndHeight" Loaded="OnInit">
     <Window.Resources>
         <local:SpecialFeaturesConverter x:Key="SpecialFeaturesConverter" />
         <ControlTemplate x:Key="ValidationTemplate">

--- a/Sample Applications/DataBindingDemo/MainWindow.cs
+++ b/Sample Applications/DataBindingDemo/MainWindow.cs
@@ -17,7 +17,7 @@ namespace DataBindingDemo
         public MainWindow()
         {
             InitializeComponent();
-            _listingDataView = (CollectionViewSource) (Resources["listingDataView"]);
+            _listingDataView = (CollectionViewSource) (Resources["ListingDataView"]);
         }
 
         private void OpenAddProductWindow(object sender, RoutedEventArgs e)

--- a/Sample Applications/DataBindingDemo/MainWindow.xaml
+++ b/Sample Applications/DataBindingDemo/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:DataBindingDemo"
         mc:Ignorable="d"
-        Title="MainWindow" Height="350" Width="525">
+        Title="List of Products" SizeToContent="WidthAndHeight">
     <Window.Resources>
         <Style TargetType="{x:Type ListBoxItem}">
             <Style.Triggers>


### PR DESCRIPTION
Fixed these things:

- Fixed OnInit method not called for the add product window.
- Fixed crash when clicking Show Groups in the main window. It pulled the wrong resource name causing null ref exception.
- Fixed window sizes and titles.