### PR TITLE
The identifier of the Resources was incorrect

### DIFF
--- a/Sample Applications/DataBindingDemo/MainWindow.cs
+++ b/Sample Applications/DataBindingDemo/MainWindow.cs
@@ -17,7 +17,7 @@ namespace DataBindingDemo
         public MainWindow()
         {
             InitializeComponent();
-            _listingDataView = (CollectionViewSource) (Resources["listingDataView"]);
+            _listingDataView = (CollectionViewSource) (Resources["ListingDataView"]);
         }
 
         private void OpenAddProductWindow(object sender, RoutedEventArgs e)


### PR DESCRIPTION
The identifier of the resource for the `ListingDataView` was incorrect, it had to start with a capital letter in the example to work.