### PR TITLE
Update default tfm to netcoreapp3.1

### DIFF
--- a/Accessibility/FetchTimer/FetchTimer.csproj
+++ b/Accessibility/FetchTimer/FetchTimer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/Accessibility/FindText/FindText/FindText.csproj
+++ b/Accessibility/FindText/FindText/FindText.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Accessibility/FocusTracker/FocusTracker.csproj
+++ b/Accessibility/FocusTracker/FocusTracker.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Accessibility/InsertText/InsertTextTarget/InsertTextTarget.csproj
+++ b/Accessibility/InsertText/InsertTextTarget/InsertTextTarget.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/Accessibility/InvokePattern/Target/Target.csproj
+++ b/Accessibility/InvokePattern/Target/Target.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Accessibility/SelectionPattern/SelectionTarget/SelectionTarget.csproj
+++ b/Accessibility/SelectionPattern/SelectionTarget/SelectionTarget.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/Accessibility/WindowMove/WindowMove.csproj
+++ b/Accessibility/WindowMove/WindowMove.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Animation/AnimationExamples/AnimationExamples.csproj
+++ b/Animation/AnimationExamples/AnimationExamples.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Animation/AnimationTiming/AnimationTiming.csproj
+++ b/Animation/AnimationTiming/AnimationTiming.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Animation/CustomAnimation/CustomAnimation.csproj
+++ b/Animation/CustomAnimation/CustomAnimation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Animation/KeyFrameAnimation/KeyFrameAnimation.csproj
+++ b/Animation/KeyFrameAnimation/KeyFrameAnimation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Animation/KeySplineAnimations/KeySplineAnimations.csproj
+++ b/Animation/KeySplineAnimations/KeySplineAnimations.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Animation/LocalAnimations/LocalAnimations.csproj
+++ b/Animation/LocalAnimations/LocalAnimations.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Animation/OpacityAnimation/OpacityAnimation.csproj
+++ b/Animation/OpacityAnimation/OpacityAnimation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Animation/PathAnimations/PathAnimations.csproj
+++ b/Animation/PathAnimations/PathAnimations.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Animation/Per-FrameAnimation/Per-FrameAnimation.csproj
+++ b/Animation/Per-FrameAnimation/Per-FrameAnimation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Animation/PropertyAnimation/PropertyAnimation.csproj
+++ b/Animation/PropertyAnimation/PropertyAnimation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Animation/TargetValues/TargetValues.csproj
+++ b/Animation/TargetValues/TargetValues.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Application Management/ApplicationShutdown/ApplicationShutdown.csproj
+++ b/Application Management/ApplicationShutdown/ApplicationShutdown.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Application Management/CodeOnlyWindowsApplication/CodeOnlyWindowsApplication.csproj
+++ b/Application Management/CodeOnlyWindowsApplication/CodeOnlyWindowsApplication.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Application Management/CustomApplication/CustomApplicationClass/CustomApplicationClass.csproj
+++ b/Application Management/CustomApplication/CustomApplicationClass/CustomApplicationClass.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Application Management/CustomApplication/CustomApplicationClient/CustomApplicationClient.csproj
+++ b/Application Management/CustomApplication/CustomApplicationClient/CustomApplicationClient.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Application Management/ExceptionHandlingSecondaryUIThread/ExceptionHandlingSecondaryUIThread.csproj
+++ b/Application Management/ExceptionHandlingSecondaryUIThread/ExceptionHandlingSecondaryUIThread.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Application Management/ExceptionHandlingSecondaryWorkerThread/ExceptionHandlingSecondaryWorkerThread.csproj
+++ b/Application Management/ExceptionHandlingSecondaryWorkerThread/ExceptionHandlingSecondaryWorkerThread.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Application Management/ProcessingCommandLineArguments/ProcessingCommandLineArguments.csproj
+++ b/Application Management/ProcessingCommandLineArguments/ProcessingCommandLineArguments.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Application Management/SkinnedApplication/SkinnedApplication.csproj
+++ b/Application Management/SkinnedApplication/SkinnedApplication.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Application Management/UnhandledExceptionHandling/UnhandledExceptionHandling.csproj
+++ b/Application Management/UnhandledExceptionHandling/UnhandledExceptionHandling.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Clipboard/ClipboardSpy/ClipboardSpy.csproj
+++ b/Clipboard/ClipboardSpy/ClipboardSpy.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Clipboard/ClipboardViewer/ClipboardViewer.csproj
+++ b/Clipboard/ClipboardViewer/ClipboardViewer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Compatibility/AppCompat-Quirks.csproj
+++ b/Compatibility/AppCompat-Quirks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>WinExe</OutputType>
     <RootNamespace>AppCompat_Quirks</RootNamespace>
     <UseWPF>true</UseWPF>

--- a/Data Binding/BindConversion/BindConversion.csproj
+++ b/Data Binding/BindConversion/BindConversion.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/BindValidation/BindValidation.csproj
+++ b/Data Binding/BindValidation/BindValidation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/BindingDPToDP/BindingDPToDP.csproj
+++ b/Data Binding/BindingDPToDP/BindingDPToDP.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/BindingToMethod/BindingToMethod.csproj
+++ b/Data Binding/BindingToMethod/BindingToMethod.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/BusinessLayerValidation/BusinessLayerValidation.csproj
+++ b/Data Binding/BusinessLayerValidation/BusinessLayerValidation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/CodeOnlyBinding/CodeOnlyBinding.csproj
+++ b/Data Binding/CodeOnlyBinding/CodeOnlyBinding.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/CollectionBinding/CollectionBinding.csproj
+++ b/Data Binding/CollectionBinding/CollectionBinding.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/CollectionViewSource/CollectionViewSource.csproj
+++ b/Data Binding/CollectionViewSource/CollectionViewSource.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/Colors/Colors.csproj
+++ b/Data Binding/Colors/Colors.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/CompositeCollections/CompositeCollections.csproj
+++ b/Data Binding/CompositeCollections/CompositeCollections.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/DataBindingToStringFomat/BindingToStringFomat.csproj
+++ b/Data Binding/DataBindingToStringFomat/BindingToStringFomat.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/DataTemplatingIntro/DataTemplatingIntro.csproj
+++ b/Data Binding/DataTemplatingIntro/DataTemplatingIntro.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/DataTrigger/DataTrigger.csproj
+++ b/Data Binding/DataTrigger/DataTrigger.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/DirectionalBinding/DirectionalBinding.csproj
+++ b/Data Binding/DirectionalBinding/DirectionalBinding.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/EditingCollections/EditingCollections.csproj
+++ b/Data Binding/EditingCollections/EditingCollections.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/Grouping/Grouping.csproj
+++ b/Data Binding/Grouping/Grouping.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/HierarchicalDataTemplate/HierarchicalDataTemplate.csproj
+++ b/Data Binding/HierarchicalDataTemplate/HierarchicalDataTemplate.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/Linq/Linq.csproj
+++ b/Data Binding/Linq/Linq.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/MasterDetail/MasterDetail.csproj
+++ b/Data Binding/MasterDetail/MasterDetail.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/MasterDetailXml/MasterDetailXml.csproj
+++ b/Data Binding/MasterDetailXml/MasterDetailXml.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/MultiBinding/MultiBinding.csproj
+++ b/Data Binding/MultiBinding/MultiBinding.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/PriorityBinding/PriorityBinding.csproj
+++ b/Data Binding/PriorityBinding/PriorityBinding.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/PropertyChangeNotification/PropertyChangeNotification.csproj
+++ b/Data Binding/PropertyChangeNotification/PropertyChangeNotification.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/SimpleBinding/SimpleBinding.csproj
+++ b/Data Binding/SimpleBinding/SimpleBinding.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/SortFilter/SortFilter.csproj
+++ b/Data Binding/SortFilter/SortFilter.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/Data Binding/UpdateSource/UpdateSource.csproj
+++ b/Data Binding/UpdateSource/UpdateSource.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/ValidateItemSample/ValidateItemSample.csproj
+++ b/Data Binding/ValidateItemSample/ValidateItemSample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/ValidateItemsInItemsControl/ValidateItemsInItemsControl.csproj
+++ b/Data Binding/ValidateItemsInItemsControl/ValidateItemsInItemsControl.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/XmlDataSource/XmlDataSource.csproj
+++ b/Data Binding/XmlDataSource/XmlDataSource.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Data Binding/XmlnsBind/XmlnsBind.csproj
+++ b/Data Binding/XmlnsBind/XmlnsBind.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Documents/Annotations/AnnotatedDocumentViewer/AnnotatedDocumentViewer.csproj
+++ b/Documents/Annotations/AnnotatedDocumentViewer/AnnotatedDocumentViewer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Documents/Annotations/AnnotationsStyling/AnnotationsStyling.csproj
+++ b/Documents/Annotations/AnnotationsStyling/AnnotationsStyling.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Documents/Fixed Documents/DocumentMerge/DocumentMerge.csproj
+++ b/Documents/Fixed Documents/DocumentMerge/DocumentMerge.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Documents/Fixed Documents/DocumentSerialization/DocumentSerialization.csproj
+++ b/Documents/Fixed Documents/DocumentSerialization/DocumentSerialization.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/Documents/Fixed Documents/DocumentStructure/DocumentStructure.csproj
+++ b/Documents/Fixed Documents/DocumentStructure/DocumentStructure.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Documents/Flow Content/FlowContentElements/FlowContentElements.csproj
+++ b/Documents/Flow Content/FlowContentElements/FlowContentElements.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Documents/Flow Content/FlowContentProperty/FlowContentProperty.csproj
+++ b/Documents/Flow Content/FlowContentProperty/FlowContentProperty.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Documents/Flow Content/FlowDocumentNewsClient/FlowDocumentNewsClient.csproj
+++ b/Documents/Flow Content/FlowDocumentNewsClient/FlowDocumentNewsClient.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Documents/Flow Content/FlowDocumentProperties/FlowDocumentProperties.csproj
+++ b/Documents/Flow Content/FlowDocumentProperties/FlowDocumentProperties.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Documents/Flow Content/FontProperties/FontProperties.csproj
+++ b/Documents/Flow Content/FontProperties/FontProperties.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Documents/Flow Content/ParagraphAndHyphenation/ParagraphAndHyphenation.csproj
+++ b/Documents/Flow Content/ParagraphAndHyphenation/ParagraphAndHyphenation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Documents/Flow Content/TableBuilder/TableBuilder.csproj
+++ b/Documents/Flow Content/TableBuilder/TableBuilder.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Documents/Flow Content/TableRows/TableRows.csproj
+++ b/Documents/Flow Content/TableRows/TableRows.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Documents/Flow Content/TabularData/TabularData.csproj
+++ b/Documents/Flow Content/TabularData/TabularData.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Documents/Flow Content/TextWrapProperty/TextWrapProperty.csproj
+++ b/Documents/Flow Content/TextWrapProperty/TextWrapProperty.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Drag and Drop/DragDropDataFormats/DragDropDataFormats.csproj
+++ b/Drag and Drop/DragDropDataFormats/DragDropDataFormats.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Drag and Drop/DragDropEvents/DragDropEvents.csproj
+++ b/Drag and Drop/DragDropEvents/DragDropEvents.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Drag and Drop/DragDropObjects/DragDropObjects.csproj
+++ b/Drag and Drop/DragDropObjects/DragDropObjects.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Drag and Drop/DragDropOpenTextFile/DragDropOpenTextFile.csproj
+++ b/Drag and Drop/DragDropOpenTextFile/DragDropOpenTextFile.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Drag and Drop/DragDropTextOps/DragDropTextOps.csproj
+++ b/Drag and Drop/DragDropTextOps/DragDropTextOps.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Drag and Drop/DragDropThumbOps/DragDropThumbOps.csproj
+++ b/Drag and Drop/DragDropThumbOps/DragDropThumbOps.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Element Tree/OverridingLogicalTree/OverridingLogicalTree.csproj
+++ b/Element Tree/OverridingLogicalTree/OverridingLogicalTree.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Element Tree/SearchingForElement/SearchingForElement.csproj
+++ b/Element Tree/SearchingForElement/SearchingForElement.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Elements/ContextMenuOpening/ContextMenuOpening.csproj
+++ b/Elements/ContextMenuOpening/ContextMenuOpening.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Elements/FindingElementInPanel/FindingElementInPanel.csproj
+++ b/Elements/FindingElementInPanel/FindingElementInPanel.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Elements/FocusVisualStyle/FocusVisualStyle.csproj
+++ b/Elements/FocusVisualStyle/FocusVisualStyle.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Elements/HeightProperties/HeightProperties.csproj
+++ b/Elements/HeightProperties/HeightProperties.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Elements/LoadedEvent/LoadedEvent.csproj
+++ b/Elements/LoadedEvent/LoadedEvent.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Elements/SettingMargins/SettingMargins.csproj
+++ b/Elements/SettingMargins/SettingMargins.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Elements/ThicknessConverter/ThicknessConverter.csproj
+++ b/Elements/ThicknessConverter/ThicknessConverter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Elements/UsingElements/UsingElements.csproj
+++ b/Elements/UsingElements/UsingElements.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Elements/VisibiltyChanges/VisibiltyChanges.csproj
+++ b/Elements/VisibiltyChanges/VisibiltyChanges.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Elements/WidthProperties/WidthProperties.csproj
+++ b/Elements/WidthProperties/WidthProperties.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Events/AddingEventHandler/AddingEventHandler.csproj
+++ b/Events/AddingEventHandler/AddingEventHandler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Events/CustomRoutedEvents/CustomRoutedEvents.csproj
+++ b/Events/CustomRoutedEvents/CustomRoutedEvents.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Events/FindingSourceElement/FindingSourceElement.csproj
+++ b/Events/FindingSourceElement/FindingSourceElement.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Events/RoutedEventHandling/RoutedEventHandling.csproj
+++ b/Events/RoutedEventHandling/RoutedEventHandling.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Getting Started/ComplexLayout/ComplexLayout.csproj
+++ b/Getting Started/ComplexLayout/ComplexLayout.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Getting Started/Concepts/Concepts.csproj
+++ b/Getting Started/Concepts/Concepts.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Getting Started/ControlsAndLayout/ControlsAndLayout/ControlsAndLayout.csproj
+++ b/Getting Started/ControlsAndLayout/ControlsAndLayout/ControlsAndLayout.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Getting Started/DynamicLayout/DynamicLayout.csproj
+++ b/Getting Started/DynamicLayout/DynamicLayout.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Getting Started/HelloWorld/HelloWorld.csproj
+++ b/Getting Started/HelloWorld/HelloWorld.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Getting Started/MultiPage/MultiPage.csproj
+++ b/Getting Started/MultiPage/MultiPage.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Getting Started/SimpleLayout/SimpleLayout.csproj
+++ b/Getting Started/SimpleLayout/SimpleLayout.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseItIntro.csproj
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseItIntro.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-  <TargetFramework>netcoreapp3.0</TargetFramework>
+  <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
     <OutputType>WinExe</OutputType>
     <RootNamespace>ExpenseIt9</RootNamespace>

--- a/Getting Started/WalkthroughFirstWPFApp/vb/ExpenseItIntro2.vbproj
+++ b/Getting Started/WalkthroughFirstWPFApp/vb/ExpenseItIntro2.vbproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
     <OutputType>WinExe</OutputType>
     <RootNamespace>ExpenseIt9</RootNamespace>

--- a/Globalization and Localization/BAML Loc/LocApp/LocApp.csproj
+++ b/Globalization and Localization/BAML Loc/LocApp/LocApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Globalization and Localization/FlowDirection/FlowDirection.csproj
+++ b/Globalization and Localization/FlowDirection/FlowDirection.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Globalization and Localization/GlobalizationHomepage/GlobalizationHomepage.csproj
+++ b/Globalization and Localization/GlobalizationHomepage/GlobalizationHomepage.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Globalization and Localization/GlobalizationRunDialog/GlobalizationRunDialog.csproj
+++ b/Globalization and Localization/GlobalizationRunDialog/GlobalizationRunDialog.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Globalization and Localization/Gradient/Gradient.csproj
+++ b/Globalization and Localization/Gradient/Gradient.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Globalization and Localization/Image/Image.csproj
+++ b/Globalization and Localization/Image/Image.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Globalization and Localization/LTRRTL/LTRRTL.csproj
+++ b/Globalization and Localization/LTRRTL/LTRRTL.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Globalization and Localization/LangAttribute/LangAttribute.csproj
+++ b/Globalization and Localization/LangAttribute/LangAttribute.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Globalization and Localization/LocalizationResources/LocalizationResources.csproj
+++ b/Globalization and Localization/LocalizationResources/LocalizationResources.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Globalization and Localization/NumbersMultipleLangauges/NumbersMultipleLangauges.csproj
+++ b/Globalization and Localization/NumbersMultipleLangauges/NumbersMultipleLangauges.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Globalization and Localization/Paths/Paths.csproj
+++ b/Globalization and Localization/Paths/Paths.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Globalization and Localization/RunSpan/RunSpan.csproj
+++ b/Globalization and Localization/RunSpan/RunSpan.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Globalization and Localization/Span/Span.csproj
+++ b/Globalization and Localization/Span/Span.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Globalization and Localization/StringLocalizationSample/StringLocalizationSample.csproj
+++ b/Globalization and Localization/StringLocalizationSample/StringLocalizationSample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/2DTransforms/2DTransforms.csproj
+++ b/Graphics/2DTransforms/2DTransforms.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/BMPEncoderAndDecoder/BMPEncoderAndDecoder.csproj
+++ b/Graphics/BMPEncoderAndDecoder/BMPEncoderAndDecoder.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/BitmapEffectsGallery/BitmapEffectsGallery.csproj
+++ b/Graphics/BitmapEffectsGallery/BitmapEffectsGallery.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/BitmapMetadata/BitmapMetadata.csproj
+++ b/Graphics/BitmapMetadata/BitmapMetadata.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/Brushes/Brushes.csproj
+++ b/Graphics/Brushes/Brushes.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/ClipRegion/ClipRegion.csproj
+++ b/Graphics/ClipRegion/ClipRegion.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/Converter/Converter.csproj
+++ b/Graphics/Converter/Converter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/CustomBitmapEffect/CustomBitmapEffect.csproj
+++ b/Graphics/CustomBitmapEffect/CustomBitmapEffect.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/DrawingBrush/DrawingBrush.csproj
+++ b/Graphics/DrawingBrush/DrawingBrush.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/GIFEncoderAndDecoder/GIFEncoderAndDecoder.csproj
+++ b/Graphics/GIFEncoderAndDecoder/GIFEncoderAndDecoder.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/Geometery/Geometery.csproj
+++ b/Graphics/Geometery/Geometery.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/ImageBrush/ImageBrush.csproj
+++ b/Graphics/ImageBrush/ImageBrush.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/ImageView/ImageView.csproj
+++ b/Graphics/ImageView/ImageView.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/JPEGEncoderAndDecoder/JPEGEncoderAndDecoder.csproj
+++ b/Graphics/JPEGEncoderAndDecoder/JPEGEncoderAndDecoder.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/Matrix/Matrix.csproj
+++ b/Graphics/Matrix/Matrix.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/OpacityMasking/OpacityMasking.csproj
+++ b/Graphics/OpacityMasking/OpacityMasking.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/PNGEncoderAndDecoder/PNGEncoderAndDecoder.csproj
+++ b/Graphics/PNGEncoderAndDecoder/PNGEncoderAndDecoder.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/Point/Point.csproj
+++ b/Graphics/Point/Point.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/ShapeElements/ShapeElements.csproj
+++ b/Graphics/ShapeElements/ShapeElements.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/ShapesGallery/ShapesGallery.csproj
+++ b/Graphics/ShapesGallery/ShapesGallery.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/SystemBrushesAndColors/SystemBrushesAndColors.csproj
+++ b/Graphics/SystemBrushesAndColors/SystemBrushesAndColors.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/TIFFEncoderAndDecoder/TIFFEncoderAndDecoder.csproj
+++ b/Graphics/TIFFEncoderAndDecoder/TIFFEncoderAndDecoder.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/Vector/Vector.csproj
+++ b/Graphics/Vector/Vector.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/VisualBrush/VisualBrush.csproj
+++ b/Graphics/VisualBrush/VisualBrush.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Graphics/WDPEncoderAndDecoder/WDPEncoderAndDecoder.csproj
+++ b/Graphics/WDPEncoderAndDecoder/WDPEncoderAndDecoder.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/CaptureUnCaptureMouse/CaptureUnCaptureMouse.csproj
+++ b/Input and Commands/CaptureUnCaptureMouse/CaptureUnCaptureMouse.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/CommandSourceControlUsingSystemTimer/CommandSourceControlUsingSystemTimer.csproj
+++ b/Input and Commands/CommandSourceControlUsingSystemTimer/CommandSourceControlUsingSystemTimer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/CommandSourceControlWithDispatcherTimer/CommandSourceControlWithDispatcherTimer.csproj
+++ b/Input and Commands/CommandSourceControlWithDispatcherTimer/CommandSourceControlWithDispatcherTimer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/CursorType/CursorType.csproj
+++ b/Input and Commands/CursorType/CursorType.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/CustomRoutedCommand/CustomRoutedCommand.csproj
+++ b/Input and Commands/CustomRoutedCommand/CustomRoutedCommand.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/EditingCommands/EditingCommands.csproj
+++ b/Input and Commands/EditingCommands/EditingCommands.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/EventOnGainAndLooseFocus/EventOnGainAndLooseFocus.csproj
+++ b/Input and Commands/EventOnGainAndLooseFocus/EventOnGainAndLooseFocus.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/HandlingEventOnCommand/HandlingEventOnCommand.csproj
+++ b/Input and Commands/HandlingEventOnCommand/HandlingEventOnCommand.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/HandlingEventOnCommandUsingCode/HandlingEventOnCommandUsingCode.csproj
+++ b/Input and Commands/HandlingEventOnCommandUsingCode/HandlingEventOnCommandUsingCode.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/ICommandSourceImplementation/ICommandSourceImplementation.csproj
+++ b/Input and Commands/ICommandSourceImplementation/ICommandSourceImplementation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/KeyStrokeCounter/KeyStrokeCounter.csproj
+++ b/Input and Commands/KeyStrokeCounter/KeyStrokeCounter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/KeyboardKey/KeyboardKey.csproj
+++ b/Input and Commands/KeyboardKey/KeyboardKey.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/MousePointer/MousePointer.csproj
+++ b/Input and Commands/MousePointer/MousePointer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/MouseState/MouseState.csproj
+++ b/Input and Commands/MouseState/MouseState.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/MoveObjectWithMouse/MoveObjectWithMouse.csproj
+++ b/Input and Commands/MoveObjectWithMouse/MoveObjectWithMouse.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Input and Commands/ProgrammaticFocusControl/ProgrammaticFocusControl.csproj
+++ b/Input and Commands/ProgrammaticFocusControl/ProgrammaticFocusControl.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Migration and Interoperability/HWNDInWPF/wpfapplication1/wpfapplication1.csproj
+++ b/Migration and Interoperability/HWNDInWPF/wpfapplication1/wpfapplication1.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Migration and Interoperability/HostingWfInWPF/HostingWfInWPF.csproj
+++ b/Migration and Interoperability/HostingWfInWPF/HostingWfInWPF.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/Migration and Interoperability/HostingWfWithVisualStyles/HostingWfWithVisualStyles.csproj
+++ b/Migration and Interoperability/HostingWfWithVisualStyles/HostingWfWithVisualStyles.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/Migration and Interoperability/HostingWpfUserControlInWf/HostingWpfUserControlInWf.csproj
+++ b/Migration and Interoperability/HostingWpfUserControlInWf/HostingWpfUserControlInWf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Migration and Interoperability/PropertyMappingWithElementHost/PropertyMappingWithElementHost.csproj
+++ b/Migration and Interoperability/PropertyMappingWithElementHost/PropertyMappingWithElementHost.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/Migration and Interoperability/WPFHostingWin32Control/WPFHostingWin32Control.csproj
+++ b/Migration and Interoperability/WPFHostingWin32Control/WPFHostingWin32Control.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Migration and Interoperability/WPFWithWFAndDatabinding/WPFWithWFAndDatabinding.csproj
+++ b/Migration and Interoperability/WPFWithWFAndDatabinding/WPFWithWFAndDatabinding.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <TargetFrameworks>net472</TargetFrameworks>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Migration and Interoperability/Win32Clock/wpfclock/wpfclock.csproj
+++ b/Migration and Interoperability/Win32Clock/wpfclock/wpfclock.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Migration and Interoperability/WindowsFormsHostingWpfControl/WPFControls/WPFControls.csproj
+++ b/Migration and Interoperability/WindowsFormsHostingWpfControl/WPFControls/WPFControls.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Migration and Interoperability/WpfHostingWindowsFormsControl/FormsControlLibrary/FormsControlLibrary.csproj
+++ b/Migration and Interoperability/WpfHostingWindowsFormsControl/FormsControlLibrary/FormsControlLibrary.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/PerMonitorDPI/FormattedTextExample/FormattedTextExample.csproj
+++ b/PerMonitorDPI/FormattedTextExample/FormattedTextExample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/PerMonitorDPI/ImageScaling/ImageScaling.csproj
+++ b/PerMonitorDPI/ImageScaling/ImageScaling.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/PerMonitorDPI/TextFormatting/TextFormatting.csproj
+++ b/PerMonitorDPI/TextFormatting/TextFormatting.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Properties/Callbacks/Callbacks.csproj
+++ b/Properties/Callbacks/Callbacks.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Properties/CustomClassesWithDP/CustomClassesWithDP.csproj
+++ b/Properties/CustomClassesWithDP/CustomClassesWithDP.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Properties/RestoringDefaultValues/RestoringDefaultValues.csproj
+++ b/Properties/RestoringDefaultValues/RestoringDefaultValues.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Resources/ApplicationResources/ApplicationResources.csproj
+++ b/Resources/ApplicationResources/ApplicationResources.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Resources/DefiningResources/DefiningResources.csproj
+++ b/Resources/DefiningResources/DefiningResources.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Resources/MergedResources/MergedResources.csproj
+++ b/Resources/MergedResources/MergedResources.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/CalculatorDemo/CalculatorDemo.csproj
+++ b/Sample Applications/CalculatorDemo/CalculatorDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/ConcentricRingsDemo/ConcentricRingsDemo.csproj
+++ b/Sample Applications/ConcentricRingsDemo/ConcentricRingsDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/CubeAnimationDemo/CubeAnimationDemo.csproj
+++ b/Sample Applications/CubeAnimationDemo/CubeAnimationDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/CustomComboBox/CustomComboBox.csproj
+++ b/Sample Applications/CustomComboBox/CustomComboBox.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
     <OutputType>WinExe</OutputType>
     <RootNamespace>CustomComboBox</RootNamespace>

--- a/Sample Applications/DataBindingDemo/DataBindingDemo.csproj
+++ b/Sample Applications/DataBindingDemo/DataBindingDemo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>WinExe</OutputType>
     <RootNamespace>DataBindingDemo</RootNamespace>

--- a/Sample Applications/DropShadow/DropShadow.csproj
+++ b/Sample Applications/DropShadow/DropShadow.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/EditingExaminerDemo/EditingExaminerDemo.csproj
+++ b/Sample Applications/EditingExaminerDemo/EditingExaminerDemo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>WinExe</OutputType>
     <RootNamespace>EditingExaminerDemo</RootNamespace>

--- a/Sample Applications/ExpenseIt/EditBoxControlLibrary/EditBoxControlLibrary.csproj
+++ b/Sample Applications/ExpenseIt/EditBoxControlLibrary/EditBoxControlLibrary.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/ExpenseItDemo.csproj
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/ExpenseItDemo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
     <OutputType>WinExe</OutputType>
     <RootNamespace>ExpenseIt9</RootNamespace>

--- a/Sample Applications/FontDialog/FontDialogDemo.csproj
+++ b/Sample Applications/FontDialog/FontDialogDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/GeometryDesignerDemo/GeometryDesignerDemo.csproj
+++ b/Sample Applications/GeometryDesignerDemo/GeometryDesignerDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/GraphingCalculatorDemo/GraphingCalculatorDemo.csproj
+++ b/Sample Applications/GraphingCalculatorDemo/GraphingCalculatorDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/HexSphereDemo/HexSphereDemo.csproj
+++ b/Sample Applications/HexSphereDemo/HexSphereDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/HtmlToXamlDemo/HtmlToXamlDemo.csproj
+++ b/Sample Applications/HtmlToXamlDemo/HtmlToXamlDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/LayoutTransitionsDemo/LayoutTransitionsDemo.csproj
+++ b/Sample Applications/LayoutTransitionsDemo/LayoutTransitionsDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/ParticlesDemo/ParticlesDemo.csproj
+++ b/Sample Applications/ParticlesDemo/ParticlesDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/PhotoFlipperDemo/PhotoFlipperDemo.csproj
+++ b/Sample Applications/PhotoFlipperDemo/PhotoFlipperDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/PhotoStoreDemo/PhotoStoreDemo.csproj
+++ b/Sample Applications/PhotoStoreDemo/PhotoStoreDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/PhotoViewerDemo/PhotoViewerDemo.csproj
+++ b/Sample Applications/PhotoViewerDemo/PhotoViewerDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/SlidePuzzleDemo/SlidePuzzleDemo.csproj
+++ b/Sample Applications/SlidePuzzleDemo/SlidePuzzleDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Sample Applications/StickyNotesDemo/StickyNotesDemo.csproj
+++ b/Sample Applications/StickyNotesDemo/StickyNotesDemo.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/Sample Applications/VideoViewerDemo/VideoViewerDemo.csproj
+++ b/Sample Applications/VideoViewerDemo/VideoViewerDemo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Speech and Media/MediaGallery/MediaGallery.csproj
+++ b/Speech and Media/MediaGallery/MediaGallery.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Styles & Templates/AlternatingAppearanceOfItems/AlternatingAppearanceOfItems.csproj
+++ b/Styles & Templates/AlternatingAppearanceOfItems/AlternatingAppearanceOfItems.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Styles & Templates/ContentControlStyle/ContentControlStyle.csproj
+++ b/Styles & Templates/ContentControlStyle/ContentControlStyle.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Styles & Templates/EventTriggers/EventTriggers.csproj
+++ b/Styles & Templates/EventTriggers/EventTriggers.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Styles & Templates/FindingElementsInTemplates/FindingElementsInTemplates.csproj
+++ b/Styles & Templates/FindingElementsInTemplates/FindingElementsInTemplates.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Styles & Templates/IntroToStylingAndTemplating/IntroToStylingAndTemplating.csproj
+++ b/Styles & Templates/IntroToStylingAndTemplating/IntroToStylingAndTemplating.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Threading/MultiThreadingWebBrowser/MultiThreadingWebBrowser.csproj
+++ b/Threading/MultiThreadingWebBrowser/MultiThreadingWebBrowser.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Threading/SingleThreadedApplication/SingleThreadedApplication.csproj
+++ b/Threading/SingleThreadedApplication/SingleThreadedApplication.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Threading/UsingDispatcher/UsingDispatcher.csproj
+++ b/Threading/UsingDispatcher/UsingDispatcher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Tools/BamlReflector/BamlReflector/BamlReflector.csproj
+++ b/Tools/BamlReflector/BamlReflector/BamlReflector.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/Tools/BamlReflector/BamlTools/BamlTools.csproj
+++ b/Tools/BamlReflector/BamlTools/BamlTools.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Net.SDK.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWpf>true</UseWpf>
   </PropertyGroup>

--- a/Visual Layer/CompositionTarget/CompositionTarget.csproj
+++ b/Visual Layer/CompositionTarget/CompositionTarget.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Visual Layer/DrawingVisual/DrawingVisual.csproj
+++ b/Visual Layer/DrawingVisual/DrawingVisual.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Visual Layer/VisualsHitTesting/VisualsHitTesting.csproj
+++ b/Visual Layer/VisualsHitTesting/VisualsHitTesting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/Windows/CustomWindowUI/CustomWindowUI.csproj
+++ b/Windows/CustomWindowUI/CustomWindowUI.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Windows/DialogBox/DialogBox.csproj
+++ b/Windows/DialogBox/DialogBox.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Windows/MessageBox/MessageBox.csproj
+++ b/Windows/MessageBox/MessageBox.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Windows/NonRectangularWindow/NonRectangularWindow.csproj
+++ b/Windows/NonRectangularWindow/NonRectangularWindow.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Windows/NotificationIcon/NotificationIcon.csproj
+++ b/Windows/NotificationIcon/NotificationIcon.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/Windows/SaveWindowState/SaveWindowState.csproj
+++ b/Windows/SaveWindowState/SaveWindowState.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Windows/ShowWindowWithoutActivation/ShowWindowWithoutActivation.csproj
+++ b/Windows/ShowWindowWithoutActivation/ShowWindowWithoutActivation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Windows/WindowActivationAndDeactivation/WindowActivationAndDeactivation.csproj
+++ b/Windows/WindowActivationAndDeactivation/WindowActivationAndDeactivation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Windows/WindowHiding/WindowHiding.csproj
+++ b/Windows/WindowHiding/WindowHiding.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Windows/WindowSizingOrder/WindowSizingOrder.csproj
+++ b/Windows/WindowSizingOrder/WindowSizingOrder.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/Windows/Wizard/Wizard.csproj
+++ b/Windows/Wizard/Wizard.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWpf>true</UseWpf>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,14 +34,9 @@ stages:
      - name: _ToolPlatform
        value: x86
      - name: _TargetFramework
-       value: 'netcoreapp3.0'
+       value: 'netcoreapp3.1'
     strategy:
      matrix:
-      Debug-AnyCPU-netcoreapp3.0:
-        _Configuration: Debug
-        _Platform: 'Any CPU'
-        _TargetFramework: 'netcoreapp3.0'
-        _ToolPlatform: x86
       Debug-AnyCPU-netcoreapp3.1:
         _Configuration: Debug
         _Platform: 'Any CPU'
@@ -52,11 +47,6 @@ stages:
         _Platform: 'Any CPU'
         _TargetFramework: 'netcoreapp5.0'
         _ToolPlatform: x86
-      Debug-x64-netcoreapp3.0:
-        _Configuration: Debug
-        _Platform: 'x64'
-        _TargetFramework: 'netcoreapp3.0'
-        _ToolPlatform: x64
       Debug-x64-netcoreapp3.1:
         _Configuration: Debug
         _Platform: 'x64'
@@ -67,11 +57,6 @@ stages:
         _Platform: 'x64'
         _TargetFramework: 'netcoreapp5.0'
         _ToolPlatform: x64
-      Debug-x86-netcoreapp3.0:
-        _Configuration: Debug
-        _Platform: 'x86'
-        _TargetFramework: 'netcoreapp3.0'
-        _ToolPlatform: x86
       Debug-x86-netcoreapp3.1:
         _Configuration: Debug
         _Platform: 'x86'
@@ -81,11 +66,6 @@ stages:
         _Configuration: Debug
         _Platform: 'x86'
         _TargetFramework: 'netcoreapp5.0'
-        _ToolPlatform: x86
-      Release-AnyCPU-netcoreapp3.0:
-        _Configuration: Release
-        _Platform: 'Any CPU'
-        _TargetFramework: 'netcoreapp3.0'
         _ToolPlatform: x86
       Release-AnyCPU-netcoreapp3.1:
         _Configuration: Release
@@ -97,11 +77,6 @@ stages:
         _Platform: 'Any CPU'
         _TargetFramework: 'netcoreapp5.0'
         _ToolPlatform: x86
-      Release-x64-netcoreapp3.0:
-        _Configuration: Release
-        _Platform: 'x64'
-        _TargetFramework: 'netcoreapp3.0'
-        _ToolPlatform: x64
       Release-x64-netcoreapp3.1:
         _Configuration: Release
         _Platform: 'x64'
@@ -112,11 +87,6 @@ stages:
         _Platform: 'x64'
         _TargetFramework: 'netcoreapp5.0'
         _ToolPlatform: x64
-      Release-x86-netcoreapp3.0:
-        _Configuration: Release
-        _Platform: 'x86'
-        _TargetFramework: 'netcoreapp3.0'
-        _ToolPlatform: x86
       Release-x86-netcoreapp3.1:
         _Configuration: Release
         _Platform: 'x86'

--- a/eng/AzurePipelinesMatrixGenerator.ps1
+++ b/eng/AzurePipelinesMatrixGenerator.ps1
@@ -7,7 +7,7 @@ Function IIf($If, $Then, $Else) {
 
 $config = @('Debug', 'Release')
 $platform = @('Any CPU', 'x86', 'x64')
-$tfm = @('netcoreapp3.0', 'netcoreapp3.1', 'netcoreapp5.0')
+$tfm = @('netcoreapp3.1', 'netcoreapp5.0')
 
 $entries = @{}
 

--- a/eng/EnsureGlobalJsonSdk.ps1
+++ b/eng/EnsureGlobalJsonSdk.ps1
@@ -18,7 +18,7 @@ param(
 
   [string] [Alias('f')]
   [Parameter(HelpMessage='TargetFramework to match from global.json/altsdk section for an alternate SDK version')]
-  [ValidateSet('', $null, 'netcoreapp3.0', 'netcoreapp3.1', 'netcoreapp5.0', IgnoreCase=$true)]
+  [ValidateSet('', $null, 'netcoreapp3.1', 'netcoreapp5.0', IgnoreCase=$true)]
   $TargetFramework=''
 )
 

--- a/eng/README.md
+++ b/eng/README.md
@@ -39,7 +39,7 @@ PARAMETERS
         You can identify this by loking at global.json sdk.version property, or <TargetFramework> property 
         in project files im this repo. 
         
-        Alternative TargetFramework can be supplied to build. Currently, netcoreapp3.0 (default), netcoreapp3.1 
+        Alternative TargetFramework can be supplied to build. Currently, netcoreapp3.1 (default),
         and netcoreapp5.0 are supported.
         
     -DryRun [<SwitchParameter>]

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -25,7 +25,7 @@
     You can identify this by loking at global.json sdk.version property, or <TargetFramework> property 
     in project files im this repo. 
     
-    Alternative TargetFramework can be supplied to build. Currently, netcoreapp3.0 (default), netcoreapp3.1 
+    Alternative TargetFramework can be supplied to build. Currently, netcoreapp3.1 (default),
     and netcoreapp5.0 are supported.
 .PARAMETER DryRun 
     When this switch is specified, the build is simulated, but the actual build is not run. 
@@ -60,7 +60,7 @@ param(
 
   [string] [Alias('f')]
   [Parameter(HelpMessage='TargetFramework to match from global.json/altsdk section for an alternate SDK version')]
-  [ValidateSet('', $null, 'netcoreapp3.0', 'netcoreapp3.1', 'netcoreapp5.0', IgnoreCase=$true)]
+  [ValidateSet('', $null, 'netcoreapp3.1', 'netcoreapp5.0', IgnoreCase=$true)]
   $TargetFramework='', 
 
   [switch]

--- a/global.json
+++ b/global.json
@@ -1,10 +1,9 @@
 {
   "sdk": {
-    "version": "3.0.101"
+    "version": "3.1.101"
   },
   "altsdk": {
-    "netcoreapp3.0":  "3.0.101",
-    "netcoreapp3.1": "3.1.100-preview2-014538",
+    "netcoreapp3.1": "3.1.101",
     "netcoreapp5.0": "5.0.100-alpha1-015754"
   }
 }


### PR DESCRIPTION
Updates default TFM to netcoreapp3.1 and switches to 3.1.100 SDK. 
.NET Core 3.0 goes out of support in a few days, so now is a good time to make this switch. 

I've created an archival tag for the code in master corresponding to netcoreapp3.0 at https://github.com/microsoft/WPF-Samples/releases/tag/v3.0.101. 

Fixes #256. 