### PR TITLE
ExpenseItIntro "Names" ListBox High Contrast Fixes

### DIFF
--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseItHome.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseItHome.xaml
@@ -47,7 +47,14 @@
             
             <!-- Name item template -->
             <DataTemplate x:Key="nameItemTemplate">
-                <Label Content="{Binding XPath=@Name}"/>
+                <!-- 
+                     When a ListBoxItem is selected, the default styles sets the Foreground to SystemColors.HighlightTextBrushKey.
+                     However, when a Label is part of the ListBoxItem, Label's default style overrides this to SystemColors.ControlTextBrushKey.
+                     This is appropriate when a Label is on its own, but not in a ListBoxItem.  To fix the contrast issues this 
+                     induces in high contrast scenarios, bind to the ListBoxItem Foreground so that we get the appropriate theme colors.
+                -->
+                <Label Content="{Binding XPath=@Name}" 
+                       Foreground="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type ListBoxItem}}}"/>
             </DataTemplate>
             
         </Grid.Resources>

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/Styles.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/Styles.xaml
@@ -25,6 +25,12 @@
         <Setter Property="Height" Value="35" />
         <Setter Property="Padding" Value="5" />
         <Setter Property="Background" Value="#4E87D4" />
+        <Style.Triggers>
+            <!-- When in high contrast modes, follow system colors to present proper contrast between adjacent colors. -->
+            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
+                <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
+            </DataTrigger>
+        </Style.Triggers>
     </Style>
 
     <!-- DataGrid header style -->
@@ -42,6 +48,12 @@
         <Setter Property="Foreground" Value="White" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalAlignment" Value="Left" />
+        <Style.Triggers>
+            <!-- When in high contrast modes, follow system colors to present proper contrast between adjacent colors. -->
+            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+            </DataTrigger>
+        </Style.Triggers>
     </Style>
 
     <!-- Button style -->


### PR DESCRIPTION
Fix multiple high contrast bugs in the styling of the "Names" ListBox while in high contrast themes.

#155 
![image](https://user-images.githubusercontent.com/20006987/74056029-fd7cf100-4995-11ea-8716-9d9cf96c6967.png)

#212 
![image](https://user-images.githubusercontent.com/20006987/74056059-0ff72a80-4996-11ea-808e-75d7f6d662c4.png)

#214
![image](https://user-images.githubusercontent.com/20006987/74056080-1dacb000-4996-11ea-9d24-4d8b44d3945e.png)

#217 
![image](https://user-images.githubusercontent.com/20006987/74056106-30bf8000-4996-11ea-8f76-494af882fa66.png)

