### PR TITLE
Additional work on refactoring

### DIFF
--- a/Getting Started/WalkthroughFirstWPFApp/csharp/App.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/App.xaml
@@ -2,5 +2,12 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="MainWindow.xaml">
-
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/ExpenseIt9;component/Styles.xaml">
+                </ResourceDictionary>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
 </Application>

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseItHome.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseItHome.xaml
@@ -1,24 +1,14 @@
-﻿
-    <Page x:Class="ExpenseIt.ExpenseItHome"
+﻿    <Page x:Class="ExpenseIt.ExpenseItHome"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       mc:Ignorable="d" 
       d:DesignHeight="350" d:DesignWidth="500"
-	Title="ExpenseIt - Home">
-    <Page.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/ExpenseIt9;component/Styles.xaml">
-                </ResourceDictionary>
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </Page.Resources>
+      Title="ExpenseIt - Home">
+
     <Grid Margin="10,0,10,10">
-       
         <Grid.Resources>
-           
             <!-- Expense Report Data -->
             <XmlDataProvider x:Key="ExpenseDataSource" XPath="Expenses">
                 <x:XData>
@@ -44,48 +34,41 @@
                     </Expenses>
                 </x:XData>
             </XmlDataProvider>
-            
             <!-- Name item template -->
             <DataTemplate x:Key="nameItemTemplate">
                 <Label Content="{Binding XPath=@Name}"/>
             </DataTemplate>
-            
         </Grid.Resources>
-      
         <Grid.Background>
             <ImageBrush ImageSource="watermark.png"  />
         </Grid.Background>
-       
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="230" />
             <ColumnDefinition />
         </Grid.ColumnDefinitions>
-        
         <Grid.RowDefinitions>
             <RowDefinition/>
             <RowDefinition Height="Auto"/>
             <RowDefinition />
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-     
+
         <!-- People list -->
-       
-        <Label Grid.Column="1" Style="{StaticResource headerTextStyle}" >
+        <Label Grid.Column="1" Style="{StaticResource HeaderTextStyle}" >
             View Expense Report
         </Label>
-        
-        <Border Grid.Column="1" Grid.Row="1" Style="{StaticResource listHeaderStyle}">
-            <Label Style="{StaticResource listHeaderTextStyle}">Names</Label>
+
+        <Border Grid.Column="1" Grid.Row="1" Style="{StaticResource ListHeaderStyle}">
+            <Label Style="{StaticResource ListHeaderTextStyle}">Names</Label>
         </Border>
-       
+
         <ListBox Name="peopleListBox" Grid.Column="1" Grid.Row="2" 
                  ItemsSource="{Binding Source={StaticResource ExpenseDataSource}, XPath=Person}"
                  ItemTemplate="{StaticResource nameItemTemplate}">
         </ListBox>
-     
+
         <!-- View report button -->
-        <Button Grid.Column="1" Grid.Row="3" Click="Button_Click" Style="{StaticResource buttonStyle}">View</Button>
-   
+        <Button Grid.Column="1" Grid.Row="3" Click="Button_Click" Style="{StaticResource ButtonStyle}">View</Button>
 
     </Grid>
 

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseItHome.xaml.cs
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseItHome.xaml.cs
@@ -13,7 +13,6 @@ namespace ExpenseIt
             InitializeComponent();
         }
 
-   
         private void Button_Click(object sender, RoutedEventArgs e)
         {
             // View Expense Report

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
@@ -1,22 +1,13 @@
-﻿
-    <Page x:Class="ExpenseIt.ExpenseReportPage"
+﻿    <Page x:Class="ExpenseIt.ExpenseReportPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       mc:Ignorable="d" 
       d:DesignHeight="350" d:DesignWidth="500"
-	Title="ExpenseIt - View Expense Report">
-    <Page.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/ExpenseIt9;component/Styles.xaml">
-                </ResourceDictionary>
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </Page.Resources>
+      Title="ExpenseIt - View Expense Report">
+
     <Grid>
-        
         <!--Templates to display expense report data-->
         <Grid.Resources>
             <!-- Reason item template -->
@@ -28,8 +19,6 @@
                 <Label Content="{Binding XPath=@ExpenseAmount}"/>
             </DataTemplate>
         </Grid.Resources>
-       
-        
         <Grid.Background>
             <ImageBrush ImageSource="watermark.png" />
         </Grid.Background>
@@ -42,8 +31,7 @@
             <RowDefinition />
         </Grid.RowDefinitions>
 
-       
-        <Label Grid.Column="1" Style="{StaticResource headerTextStyle}">
+        <Label Grid.Column="1" Style="{StaticResource HeaderTextStyle}">
             Expense Report For:
         </Label>
         <Grid Margin="10" Grid.Column="1" Grid.Row="1">
@@ -58,29 +46,25 @@
                 <RowDefinition />
             </Grid.RowDefinitions> 
 
-           
             <!-- Name -->
             <StackPanel Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Orientation="Horizontal">
-                <Label Style="{StaticResource labelStyle}">Name:</Label>
-                <Label Style="{StaticResource labelStyle}" Content="{Binding XPath=@Name}"></Label>
+                <Label Style="{StaticResource LabelStyle}">Name:</Label>
+                <Label Style="{StaticResource LabelStyle}" Content="{Binding XPath=@Name}"></Label>
             </StackPanel>
 
             <!-- Department -->
             <StackPanel Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" Orientation="Horizontal">
-                <Label Style="{StaticResource labelStyle}">Department:</Label>
-                <Label Style="{StaticResource labelStyle}" Content="{Binding XPath=@Department}"></Label>
+                <Label Style="{StaticResource LabelStyle}">Department:</Label>
+                <Label Style="{StaticResource LabelStyle}" Content="{Binding XPath=@Department}"></Label>
             </StackPanel>
-            
             <Grid Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Left">
 
                 <!-- Expense type and Amount table -->
-                <DataGrid ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource columnHeaderStyle}" AutoGenerateColumns="False" RowHeaderWidth="0" >
-                   
+                <DataGrid ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" RowHeaderWidth="0" >
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="ExpenseType" Binding="{Binding XPath=@ExpenseType}"  />
                         <DataGridTextColumn Header="Amount" Binding="{Binding XPath=@ExpenseAmount}" />
                     </DataGrid.Columns>
-                    
                 </DataGrid>
 
             </Grid>

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/MainWindow.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/MainWindow.xaml
@@ -1,8 +1,6 @@
-﻿
-    <NavigationWindow x:Class="ExpenseIt.MainWindow"
+﻿    <NavigationWindow x:Class="ExpenseIt.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="ExpenseIt" Height="350" Width="500" Source="ExpenseItHome.xaml">
-    
-</NavigationWindow>
+    </NavigationWindow>
 

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/Styles.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/Styles.xaml
@@ -2,9 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:ExpenseIt9">
 
-
     <!-- Header text style -->
-    <Style x:Key="headerTextStyle">
+    <Style x:Key="HeaderTextStyle">
         <Setter Property="Label.VerticalAlignment" Value="Center"></Setter>
         <Setter Property="Label.FontFamily" Value="Trebuchet MS"></Setter>
         <Setter Property="Label.FontWeight" Value="Bold"></Setter>
@@ -13,7 +12,7 @@
     </Style>
 
     <!-- Label style -->
-    <Style x:Key="labelStyle" TargetType="{x:Type Label}">
+    <Style x:Key="LabelStyle" TargetType="{x:Type Label}">
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="FontWeight" Value="Bold" />
@@ -21,31 +20,29 @@
     </Style>
 
     <!-- List header style -->
-    <Style x:Key="listHeaderStyle" TargetType="{x:Type Border}">
+    <Style x:Key="ListHeaderStyle" TargetType="{x:Type Border}">
         <Setter Property="Height" Value="35" />
         <Setter Property="Padding" Value="5" />
         <Setter Property="Background" Value="#4E87D4" />
     </Style>
 
     <!-- DataGrid header style -->
-    <Style x:Key="columnHeaderStyle" TargetType="{x:Type DataGridColumnHeader}">
+    <Style x:Key="ColumnHeaderStyle" TargetType="{x:Type DataGridColumnHeader}">
         <Setter Property="Height" Value="35" />
         <Setter Property="Padding" Value="5" />
         <Setter Property="Background" Value="#4E87D4" />
         <Setter Property="Foreground" Value="White" />
-
-
     </Style>
 
     <!-- List header text style -->
-    <Style x:Key="listHeaderTextStyle" TargetType="{x:Type Label}">
+    <Style x:Key="ListHeaderTextStyle" TargetType="{x:Type Label}">
         <Setter Property="Foreground" Value="White" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalAlignment" Value="Left" />
     </Style>
 
     <!-- Button style -->
-    <Style x:Key="buttonStyle" TargetType="{x:Type Button}">
+    <Style x:Key="ButtonStyle" TargetType="{x:Type Button}">
         <Setter Property="Width" Value="125" />
         <Setter Property="Height" Value="25" />
         <Setter Property="Margin" Value="0,10,0,0" />

--- a/Getting Started/WalkthroughFirstWPFApp/vb/Application.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/vb/Application.xaml
@@ -2,5 +2,12 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="MainWindow.xaml">
-
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/ExpenseIt9;component/Styles.xaml">
+                </ResourceDictionary>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
 </Application>

--- a/Getting Started/WalkthroughFirstWPFApp/vb/ExpenseItHome.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/vb/ExpenseItHome.xaml
@@ -1,20 +1,11 @@
-﻿
-    <Page x:Class="ExpenseIt.ExpenseItHome"
+﻿    <Page x:Class="ExpenseIt.ExpenseItHome"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       mc:Ignorable="d" 
       d:DesignHeight="350" d:DesignWidth="500"
-	Title="ExpenseIt - Home">
-    <Page.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/ExpenseIt9;component/Styles.xaml">
-                </ResourceDictionary>
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </Page.Resources>
+      Title="ExpenseIt - Home">
     <Grid Margin="10,0,10,10">
        
         <Grid.Resources>
@@ -70,11 +61,11 @@
      
         <!-- People list -->
        
-        <Label Grid.Column="1" Style="{StaticResource headerTextStyle}" >
+        <Label Grid.Column="1" Style="{StaticResource HeaderTextStyle}" >
             View Expense Report
         </Label>
         
-        <Border Grid.Column="1" Grid.Row="1" Style="{StaticResource listHeaderStyle}">
+        <Border Grid.Column="1" Grid.Row="1" Style="{StaticResource ListHeaderStyle}">
             <Label Style="{StaticResource listHeaderTextStyle}">Names</Label>
         </Border>
        
@@ -84,7 +75,7 @@
         </ListBox>
      
         <!-- View report button -->
-        <Button Grid.Column="1" Grid.Row="3" Click="Button_Click" Style="{StaticResource buttonStyle}">View</Button>
+        <Button Grid.Column="1" Grid.Row="3" Click="Button_Click" Style="{StaticResource ButtonStyle}">View</Button>
    
 
     </Grid>

--- a/Getting Started/WalkthroughFirstWPFApp/vb/ExpenseReportPage.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/vb/ExpenseReportPage.xaml
@@ -1,20 +1,12 @@
-﻿
-    <Page x:Class="ExpenseIt.ExpenseReportPage"
+﻿    <Page x:Class="ExpenseIt.ExpenseReportPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       mc:Ignorable="d" 
       d:DesignHeight="350" d:DesignWidth="500"
-	Title="ExpenseIt - View Expense Report">
-    <Page.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/ExpenseIt9;component/Styles.xaml">
-                </ResourceDictionary>
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </Page.Resources>
+      Title="ExpenseIt - View Expense Report">
+
     <Grid>
         
         <!--Templates to display expense report data-->
@@ -43,7 +35,7 @@
         </Grid.RowDefinitions>
 
        
-        <Label Grid.Column="1" Style="{StaticResource headerTextStyle}">
+        <Label Grid.Column="1" Style="{StaticResource HeaderTextStyle}">
             Expense Report For:
         </Label>
         <Grid Margin="10" Grid.Column="1" Grid.Row="1">
@@ -61,14 +53,14 @@
            
             <!-- Name -->
             <StackPanel Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Orientation="Horizontal">
-                <Label Style="{StaticResource labelStyle}">Name:</Label>
-                <Label Style="{StaticResource labelStyle}" Content="{Binding XPath=@Name}"></Label>
+                <Label Style="{StaticResource LabelStyle}">Name:</Label>
+                <Label Style="{StaticResource LabelStyle}" Content="{Binding XPath=@Name}"></Label>
             </StackPanel>
 
             <!-- Department -->
             <StackPanel Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" Orientation="Horizontal">
-                <Label Style="{StaticResource labelStyle}">Department:</Label>
-                <Label Style="{StaticResource labelStyle}" Content="{Binding XPath=@Department}"></Label>
+                <Label Style="{StaticResource LabelStyle}">Department:</Label>
+                <Label Style="{StaticResource LabelStyle}" Content="{Binding XPath=@Department}"></Label>
             </StackPanel>
            
             <Grid Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Left">
@@ -76,7 +68,7 @@
                
 
                 <!-- Expense type and Amount table -->
-                <DataGrid ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource columnHeaderStyle}" AutoGenerateColumns="False" RowHeaderWidth="0" >
+                <DataGrid ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" RowHeaderWidth="0" >
                    
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="ExpenseType" Binding="{Binding XPath=@ExpenseType}"  />

--- a/Getting Started/WalkthroughFirstWPFApp/vb/MainWindow.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/vb/MainWindow.xaml
@@ -1,8 +1,6 @@
-﻿
-    <NavigationWindow x:Class="ExpenseIt.MainWindow"
+﻿<NavigationWindow x:Class="ExpenseIt.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="ExpenseIt" Height="350" Width="500" Source="ExpenseItHome.xaml">
-    
-</NavigationWindow>
+        Title="ExpenseIt" Height="350" Width="500" Source="ExpenseItHome.xaml" />
+
 

--- a/Getting Started/WalkthroughFirstWPFApp/vb/Styles.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/vb/Styles.xaml
@@ -3,7 +3,7 @@
     xmlns:local="clr-namespace:ExpenseIt9">
 
     <!-- Header text style -->
-    <Style x:Key="headerTextStyle">
+    <Style x:Key="HeaderTextStyle">
         <Setter Property="Label.VerticalAlignment" Value="Center"></Setter>
         <Setter Property="Label.FontFamily" Value="Trebuchet MS"></Setter>
         <Setter Property="Label.FontWeight" Value="Bold"></Setter>
@@ -12,7 +12,7 @@
     </Style>
 
     <!-- Label style -->
-    <Style x:Key="labelStyle" TargetType="{x:Type Label}">
+    <Style x:Key="LabelStyle" TargetType="{x:Type Label}">
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="FontWeight" Value="Bold" />
@@ -20,14 +20,14 @@
     </Style>
 
     <!-- List header style -->
-    <Style x:Key="listHeaderStyle" TargetType="{x:Type Border}">
+    <Style x:Key="ListHeaderStyle" TargetType="{x:Type Border}">
         <Setter Property="Height" Value="35" />
         <Setter Property="Padding" Value="5" />
         <Setter Property="Background" Value="#4E87D4" />
     </Style>
 
     <!-- DataGrid header style -->
-    <Style x:Key="columnHeaderStyle" TargetType="{x:Type DataGridColumnHeader}">
+    <Style x:Key="ColumnHeaderStyle" TargetType="{x:Type DataGridColumnHeader}">
         <Setter Property="Height" Value="35" />
         <Setter Property="Padding" Value="5" />
         <Setter Property="Background" Value="#4E87D4" />
@@ -42,7 +42,7 @@
     </Style>
 
     <!-- Button style -->
-    <Style x:Key="buttonStyle" TargetType="{x:Type Button}">
+    <Style x:Key="ButtonStyle" TargetType="{x:Type Button}">
         <Setter Property="Width" Value="125" />
         <Setter Property="Height" Value="25" />
         <Setter Property="Margin" Value="0,10,0,0" />

--- a/Sample Applications/CustomComboBox/Styles.xaml
+++ b/Sample Applications/CustomComboBox/Styles.xaml
@@ -21,6 +21,103 @@
         </Setter>
     </Style>
 
+    <ControlTemplate x:Key="VerticalScrollBar" TargetType="{x:Type ScrollBar}">
+        <Grid Width="12">
+            <Track x:Name="PART_Track" HorizontalAlignment="Center"
+                       IsDirectionReversed="true">
+                <Track.Thumb>
+                    <Thumb Style="{StaticResource ScrollBarThumb}" Margin="1,0">
+                        <Thumb.BorderBrush>
+                            <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
+                                <GradientStop Offset="0" Color="Gray"/>
+                                <GradientStop Offset="0.5" Color="Black"/>
+                                <GradientStop Offset="1" Color="Gray"/>
+                            </LinearGradientBrush>
+                        </Thumb.BorderBrush>
+
+                        <Thumb.Background>
+                            <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
+                                <GradientStop Color="Gray" Offset="0.0" x:Name="stopa"/>
+                                <GradientStop Color="Black" Offset="1.0" x:Name="stopb"/>
+                            </LinearGradientBrush>
+                        </Thumb.Background>
+                    </Thumb>
+                </Track.Thumb>
+            </Track>
+        </Grid>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="HorizontalScrollBar" TargetType="{x:Type ScrollBar}">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition MaxWidth="18" />
+                <ColumnDefinition Width="0.00001*" />
+                <ColumnDefinition MaxWidth="18" />
+            </Grid.ColumnDefinitions>
+            <Border Grid.ColumnSpan="3"
+                        CornerRadius="2"
+                        Background="#F0F0F0" />
+            <Track x:Name="PART_Tracka"
+                       Grid.Column="1"
+                       IsDirectionReversed="False">
+                <Track.Thumb>
+                    <Thumb Style="{StaticResource ScrollBarThumb}" Margin="0,1">
+                    </Thumb>
+                </Track.Thumb>
+            </Track>
+        </Grid>
+    </ControlTemplate>
+
+    <Style x:Key="ScrollBarStyle" TargetType="{x:Type ScrollBar}">
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="SmallChange" Value="1" />
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="Margin" Value="-3,3" />
+        <Style.Triggers>
+            <Trigger Property="Orientation" Value="Horizontal">
+                <Setter Property="Template" Value="{StaticResource HorizontalScrollBar}" />
+            </Trigger>
+            <Trigger Property="Orientation" Value="Vertical">
+                <Setter Property="Width" Value="15" />
+                <Setter Property="Height" Value="Auto" />
+                <Setter Property="Template" Value="{StaticResource VerticalScrollBar}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <LinearGradientBrush x:Key="btn3d" StartPoint="0.5,0" EndPoint="0.5,1">
+        <GradientStop Offset="0" Color="Gray"/>
+        <GradientStop Offset="1" Color="Black"/>
+    </LinearGradientBrush>
+
+    <Storyboard x:Key="selectedItemStoryboard">
+        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Border" Storyboard.TargetProperty="Background">
+            <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                <DiscreteObjectKeyFrame.Value>
+                    <LinearGradientBrush>
+                        <GradientStop Offset="0.2" Color="Black"/>
+                        <GradientStop Offset="0.6" Color="#73ffd700"/>
+                        <GradientStop Offset="0.65" Color="Black"/>
+                    </LinearGradientBrush>
+                </DiscreteObjectKeyFrame.Value>
+            </DiscreteObjectKeyFrame>
+        </ObjectAnimationUsingKeyFrames>
+
+        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Border" Storyboard.TargetProperty="BorderBrush">
+            <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                <DiscreteObjectKeyFrame.Value>
+                    <LinearGradientBrush>
+                        <GradientStop Offset="0" Color="White"/>
+                        <GradientStop Offset="0.25" Color="Black"/>
+                        <GradientStop Offset="0.5" Color="White"/>
+                        <GradientStop Offset="0.75" Color="Black"/>
+                        <GradientStop Offset="1" Color="White"/>
+                    </LinearGradientBrush>
+                </DiscreteObjectKeyFrame.Value>
+            </DiscreteObjectKeyFrame>
+        </ObjectAnimationUsingKeyFrames>
+    </Storyboard>
+
     <Style x:Key="listBoxStyle" TargetType="ListBox">
         <Setter Property="Foreground" Value="#AEAEAE"/>
         <Setter Property="Template">
@@ -194,102 +291,5 @@
             </Setter.Value>
         </Setter>
     </Style>
-
-    <ControlTemplate x:Key="VerticalScrollBar" TargetType="{x:Type ScrollBar}">
-        <Grid Width="12">
-            <Track x:Name="PART_Track" HorizontalAlignment="Center"
-                       IsDirectionReversed="true">
-                <Track.Thumb>
-                    <Thumb Style="{StaticResource ScrollBarThumb}" Margin="1,0">
-                        <Thumb.BorderBrush>
-                            <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
-                                <GradientStop Offset="0" Color="Gray"/>
-                                <GradientStop Offset="0.5" Color="Black"/>
-                                <GradientStop Offset="1" Color="Gray"/>
-                            </LinearGradientBrush>
-                        </Thumb.BorderBrush>
-
-                        <Thumb.Background>
-                            <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
-                                <GradientStop Color="Gray" Offset="0.0" x:Name="stopa"/>
-                                <GradientStop Color="Black" Offset="1.0" x:Name="stopb"/>
-                            </LinearGradientBrush>
-                        </Thumb.Background>
-                    </Thumb>
-                </Track.Thumb>
-            </Track>
-        </Grid>
-    </ControlTemplate>
-
-    <ControlTemplate x:Key="HorizontalScrollBar" TargetType="{x:Type ScrollBar}">
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition MaxWidth="18" />
-                <ColumnDefinition Width="0.00001*" />
-                <ColumnDefinition MaxWidth="18" />
-            </Grid.ColumnDefinitions>
-            <Border Grid.ColumnSpan="3"
-                        CornerRadius="2"
-                        Background="#F0F0F0" />
-            <Track x:Name="PART_Tracka"
-                       Grid.Column="1"
-                       IsDirectionReversed="False">
-                <Track.Thumb>
-                    <Thumb Style="{StaticResource ScrollBarThumb}" Margin="0,1">
-                    </Thumb>
-                </Track.Thumb>
-            </Track>
-        </Grid>
-    </ControlTemplate>
-
-    <Style x:Key="ScrollBarStyle" TargetType="{x:Type ScrollBar}">
-        <Setter Property="SnapsToDevicePixels" Value="True" />
-        <Setter Property="SmallChange" Value="1" />
-        <Setter Property="OverridesDefaultStyle" Value="true" />
-        <Setter Property="Margin" Value="-3,3" />
-        <Style.Triggers>
-            <Trigger Property="Orientation" Value="Horizontal">
-                <Setter Property="Template" Value="{StaticResource HorizontalScrollBar}" />
-            </Trigger>
-            <Trigger Property="Orientation" Value="Vertical">
-                <Setter Property="Width" Value="15" />
-                <Setter Property="Height" Value="Auto" />
-                <Setter Property="Template" Value="{StaticResource VerticalScrollBar}" />
-            </Trigger>
-        </Style.Triggers>
-    </Style>
-
-    <LinearGradientBrush x:Key="btn3d" StartPoint="0.5,0" EndPoint="0.5,1">
-        <GradientStop Offset="0" Color="Gray"/>
-        <GradientStop Offset="1" Color="Black"/>
-    </LinearGradientBrush>
-
-    <Storyboard x:Key="selectedItemStoryboard">
-        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Border" Storyboard.TargetProperty="Background">
-            <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                <DiscreteObjectKeyFrame.Value>
-                    <LinearGradientBrush>
-                        <GradientStop Offset="0.2" Color="Black"/>
-                        <GradientStop Offset="0.6" Color="#73ffd700"/>
-                        <GradientStop Offset="0.65" Color="Black"/>
-                    </LinearGradientBrush>
-                </DiscreteObjectKeyFrame.Value>
-            </DiscreteObjectKeyFrame>
-        </ObjectAnimationUsingKeyFrames>
-
-        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Border" Storyboard.TargetProperty="BorderBrush">
-            <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                <DiscreteObjectKeyFrame.Value>
-                    <LinearGradientBrush>
-                        <GradientStop Offset="0" Color="White"/>
-                        <GradientStop Offset="0.25" Color="Black"/>
-                        <GradientStop Offset="0.5" Color="White"/>
-                        <GradientStop Offset="0.75" Color="Black"/>
-                        <GradientStop Offset="1" Color="White"/>
-                    </LinearGradientBrush>
-                </DiscreteObjectKeyFrame.Value>
-            </DiscreteObjectKeyFrame>
-        </ObjectAnimationUsingKeyFrames>
-    </Storyboard>
 
 </ResourceDictionary>

--- a/Sample Applications/DataBindingDemo/AddProductWindow.xaml
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.xaml
@@ -7,10 +7,6 @@
         mc:Ignorable="d"
         Title="Add Product Listing" SizeToContent="WidthAndHeight" Loaded="OnInit">
     <Window.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/DataBindingDemo;component/Styles.xaml"/>
-            </ResourceDictionary.MergedDictionaries>
             <local:SpecialFeaturesConverter x:Key="SpecialFeaturesConverter" />
             <ControlTemplate x:Key="ValidationTemplate">
                 <DockPanel>
@@ -18,7 +14,6 @@
                     <AdornedElementPlaceholder />
                 </DockPanel>
             </ControlTemplate>
-        </ResourceDictionary>
     </Window.Resources>
 
     <Border Padding="20">
@@ -29,7 +24,7 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Border Grid.Row="0"
-                    Style="{StaticResource borderStyle2}">
+                    Style="{StaticResource BorderStyle}">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition />

--- a/Sample Applications/DataBindingDemo/App.xaml
+++ b/Sample Applications/DataBindingDemo/App.xaml
@@ -13,7 +13,7 @@
             <local:DateConverter x:Key="DateConverter" />
 
             <DataTemplate DataType="{x:Type local:AuctionItem}" >
-                <Border Style="{StaticResource borderStyle1}" Name="border">
+                <Border Style="{StaticResource AuctionItemBorderStyle}" Name="border">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition />
@@ -29,7 +29,7 @@
 
                         <Polygon Grid.Row="0" Grid.Column="0" Grid.RowSpan="4"
                                  Name="star"
-                                 Style="{StaticResource polygonStyle1}"
+                                 Style="{StaticResource PolygonStyle}"
                                  Points="9,2 11,7 17,7 12,10 14,15 9,12 4,15 6,10 1,7 7,7"/>
 
                         <TextBlock Grid.Row="0" Grid.Column="1" Margin="0,0,8,0"

--- a/Sample Applications/DataBindingDemo/MainWindow.xaml
+++ b/Sample Applications/DataBindingDemo/MainWindow.xaml
@@ -7,10 +7,6 @@
         mc:Ignorable="d"
         Title="List of Products" SizeToContent="WidthAndHeight">
     <Window.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/DataBindingDemo;component/Styles.xaml"/>
-            </ResourceDictionary.MergedDictionaries>
             <DataTemplate x:Key="GroupingHeaderTemplate">
                 <TextBlock Text="{Binding Path=Name}"
                            Foreground="Navy" FontWeight="Bold" FontSize="12" />
@@ -19,7 +15,6 @@
             <CollectionViewSource
                 Source="{Binding Source={x:Static Application.Current}, Path=AuctionItems}"
                 x:Key="ListingDataView" />
-        </ResourceDictionary>
     </Window.Resources>
 
     <Grid>

--- a/Sample Applications/DataBindingDemo/Styles.xaml
+++ b/Sample Applications/DataBindingDemo/Styles.xaml
@@ -39,7 +39,7 @@
         <Setter Property="Foreground" Value="#333333" />
     </Style>
 
-    <Style x:Key="borderStyle1" TargetType="Border">
+    <Style x:Key="AuctionItemBorderStyle" TargetType="Border">
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="BorderBrush" Value="Gray" />
         <Setter Property="Padding" Value="7" />
@@ -47,13 +47,13 @@
         <Setter Property="Width" Value="500" />
     </Style>
 
-    <Style x:Key="borderStyle2" TargetType="Border">
+    <Style x:Key="BorderStyle" TargetType="Border">
         <Setter Property="BorderThickness" Value="0,0,0,2" />
         <Setter Property="BorderBrush" Value="Black" />
         <Setter Property="Padding" Value="5" />
     </Style>
 
-    <Style x:Key="polygonStyle1" TargetType="Polygon">
+    <Style x:Key="PolygonStyle" TargetType="Polygon">
         <Setter Property="Fill" Value="Yellow"/>
         <Setter Property="Stroke" Value="Black" />
         <Setter Property="StrokeThickness" Value="1" />

--- a/Sample Applications/EditingExaminerDemo/App.xaml
+++ b/Sample Applications/EditingExaminerDemo/App.xaml
@@ -2,4 +2,12 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:EditingExaminerDemo"
-             StartupUri="MainWindow.xaml" />
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/EditingExaminerDemo;component/Styles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/Sample Applications/EditingExaminerDemo/MainWindow.xaml
+++ b/Sample Applications/EditingExaminerDemo/MainWindow.xaml
@@ -10,13 +10,6 @@
     MinHeight="600"
     MinWidth="750"
     SizeChanged="window_SizeChanged">
-    <Window.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/EditingExaminerDemo;component/Styles.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </Window.Resources>
     <StackPanel Name="TopPanel" Width="800" Height="600">
         <StackPanel Name="Panel1" Orientation="Vertical">
             <TabControl Name="MainTab" SelectionChanged="UpdateDisplayTabs">
@@ -30,7 +23,7 @@
                 </TabItem>
                 <TabItem Header="Help"
                          AutomationProperties.HelpText="Help Tab: The content in this tab explains how to use the demo.">
-                    <FlowDocumentScrollViewer Margin="10" Style="{StaticResource scrollViewer1}">
+                    <FlowDocumentScrollViewer Margin="10" Style="{StaticResource ScrollViewer}">
                         <FlowDocument
                             ColumnWidth="400"
                             IsOptimalParagraphEnabled="True" IsHyphenationEnabled="True">
@@ -209,7 +202,7 @@ Selection = RichTextBox.Selection;
                 </TabItem>
             </TabControl>
             <StackPanel Name="Panel3">
-                <Label Name="Label1" BorderThickness="1,0,1,0" Style="{StaticResource labelStyle1}" HorizontalContentAlignment="Center"
+                <Label Name="Label1" BorderThickness="1,0,1,0" Style="{StaticResource ImmediateWindowLabel}" HorizontalContentAlignment="Center"
                        Width="400" Height="25">
                     Immediate Window
                 </Label>
@@ -222,7 +215,7 @@ Selection = RichTextBox.Selection;
             </StackPanel>
         </StackPanel>
         <StackPanel Name="Panel4">
-            <TextBox Name="ErrorMessageBox" Height="60" IsReadOnly="True" Style="{StaticResource textBoxStyle1}">No exception!</TextBox>
+            <TextBox Name="ErrorMessageBox" Height="60" IsReadOnly="True" Style="{StaticResource ErrorMessageTextBox}">No exception!</TextBox>
         </StackPanel>
     </StackPanel>
 </Window>

--- a/Sample Applications/EditingExaminerDemo/Styles.xaml
+++ b/Sample Applications/EditingExaminerDemo/Styles.xaml
@@ -2,16 +2,16 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:EditingExaminerDemo">
 
-    <Style x:Key="scrollViewer1" TargetType="FlowDocumentScrollViewer">
+    <Style x:Key="ScrollViewer" TargetType="FlowDocumentScrollViewer">
         <Setter Property="BorderBrush" Value="Black" />
         <Setter Property="BorderThickness" Value="1" />
     </Style>
 
-    <Style x:Key="labelStyle1" TargetType="Label">
+    <Style x:Key="ImmediateWindowLabel" TargetType="Label">
         <Setter Property="BorderBrush" Value="Gray"/>
     </Style>
 
-    <Style x:Key="textBoxStyle1" TargetType="TextBox">
+    <Style x:Key="ErrorMessageTextBox" TargetType="TextBox">
         <Setter Property="Foreground" Value="Red" />
         <Setter Property="BorderBrush" Value="Red" />
     </Style>

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/App.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/App.xaml
@@ -1,17 +1,14 @@
 ﻿<Application x:Class="ExpenseItDemo.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:ExpenseItDemo"
              StartupUri="MainWindow.xaml">
     
     <Application.Resources>
 
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/ExpenseIt9;component/Styles.xaml">
-                </ResourceDictionary>
+                <ResourceDictionary Source="/ExpenseIt9;component/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
-
             <ExpenseReport x:Key="ExpenseData"
                        xmlns="clr-namespace:ExpenseItDemo"
                        Alias="Someone@example.com"
@@ -57,7 +54,7 @@
                     </Grid.RowDefinitions>
                     <Rectangle Grid.Row="0"
                            Height="{Binding Path=Cost}"
-                           Style="{StaticResource ExpenseRectangle1}">
+                           Style="{StaticResource ExpenseRectangleBrackground}">
                         <Rectangle.RenderTransform>
                             <TranslateTransform X="1"
                                             Y="1" />
@@ -65,11 +62,11 @@
                     </Rectangle>
                     <Rectangle Grid.Row="0"
                            Height="{Binding Path=Cost}"
-                           Style="{StaticResource ExpenseRectangle2}">
+                           Style="{StaticResource BarsInExpenseChart}">
                     </Rectangle>
                     <Rectangle Grid.Row="0"
                            Height="{Binding Path=Cost}"
-                           Style="{StaticResource ExpenseRectangle3}">
+                           Style="{StaticResource ExpenseChartRectangle}">
                     </Rectangle>
                     <Viewbox Grid.Row="1"
                          Style="{StaticResource ExpenseViewbox}">
@@ -82,6 +79,5 @@
                 </Grid>
             </DataTemplate>
         </ResourceDictionary>
-
     </Application.Resources>
 </Application>

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/CreateExpenseReportDialogBox.cs
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/CreateExpenseReportDialogBox.cs
@@ -43,5 +43,6 @@ namespace ExpenseItDemo
         {
             DialogResult = false;
         }
+
     }
 }

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/CreateExpenseReportDialogBox.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/CreateExpenseReportDialogBox.xaml
@@ -11,41 +11,7 @@
     ShowInTaskbar="False"
     WindowStartupLocation="CenterOwner">
 
-    <Window.Resources>
-
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/ExpenseIt9;component/Styles.xaml">
-                </ResourceDictionary>
-            </ResourceDictionary.MergedDictionaries>
-
-            <DataTemplate x:Key="ExpenseTemplate">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="33*" />
-                        <ColumnDefinition Width="33*" />
-                        <ColumnDefinition Width="33*" />
-                    </Grid.ColumnDefinitions>
-                    <TextBox Text="{Binding Path=Type}" Grid.Column="0" />
-                    <TextBox Text="{Binding Path=Description}" Grid.Column="1" />
-                    <TextBox Grid.Column="2" TextAlignment="Right">
-                        <TextBox.Text>
-                            <Binding Path="Cost" UpdateSourceTrigger="PropertyChanged">
-                                <!-- SECURITY: Cost must be an int -->
-                                <Binding.ValidationRules>
-                                    <localValidation:NumberValidationRule />
-                                </Binding.ValidationRules>
-                            </Binding>
-                        </TextBox.Text>
-                    </TextBox>
-                </Grid>
-            </DataTemplate>
-         </ResourceDictionary>
-
-    </Window.Resources>
-
     <Grid>
-
         <!-- Watermark -->
         <Image Style="{StaticResource WatermarkImage}" />
 
@@ -82,7 +48,7 @@
                 </Grid.RowDefinitions>
 
                 <!-- Alias -->
-                <Label Style="{StaticResource Label}" Target="{Binding ElementName=Alias}" Grid.Column="2" Grid.Row="0">
+                <Label Style="{StaticResource Label}" Target="{Binding ElementName=aliasTextBox}" Grid.Column="2" Grid.Row="0">
                     Email _Alias:
                 </Label>
                 <TextBox Name="aliasTextBox" Style="{StaticResource ReadOnlyText}" Grid.Column="3" Grid.Row="0"
@@ -93,7 +59,7 @@
                 </TextBox>
 
                 <!-- Employee Number -->
-                <Label Style="{StaticResource Label}" Target="{Binding ElementName=Number}" Grid.Column="2"
+                <Label Style="{StaticResource Label}" Target="{Binding ElementName=employeeNumberTextBox}" Grid.Column="2"
                        Grid.Row="1">
                     Employee _Number:
                 </Label>
@@ -105,7 +71,7 @@
                 </TextBox>
 
                 <!-- Cost Center -->
-                <Label Style="{StaticResource Label}" Target="{Binding ElementName=costCenter}" Grid.Column="2"
+                <Label Style="{StaticResource Label}" Target="{Binding ElementName=costCenterTextBox}" Grid.Column="2"
                        Grid.Row="2">
                     _Cost Center:
                 </Label>
@@ -125,7 +91,7 @@
             <StackPanel Grid.Row="2" Grid.Column="2" Grid.RowSpan="2">
 
                 <!-- Add Expense Button -->
-                <Button Style="{StaticResource FunctionButton}" Click="addExpenseButton_Click">
+                <Button Style="{StaticResource FunctionButton}" Click="addExpenseButton_Click" Name="addExpenseButton">
                     Add _Expense
                     <Button.ToolTip>
                         <TextBlock>add expense</TextBlock>
@@ -133,12 +99,14 @@
                 </Button>
 
                 <!-- View Chart Button-->
-                <Button Style="{StaticResource FunctionButton}" Click="viewChartButton_Click">
+                <Button Style="{StaticResource FunctionButton}" Click="viewChartButton_Click" Name="viewExpenseButton">
                     <Button.ToolTip>
                         <TextBlock>View chart</TextBlock>
                     </Button.ToolTip>
-                    <DockPanel>
-                        <TextBlock DockPanel.Dock="Top" TextAlignment="Center">View Chart</TextBlock>
+                    <DockPanel KeyboardNavigation.TabNavigation="None">
+                        <Label DockPanel.Dock="Top" Target="{Binding ElementName=viewExpenseButton}" HorizontalAlignment="Center">
+                            _View Chart
+                        </Label>
                         <ItemsControl Style="{StaticResource ExpenseChartSmall}" />
                     </DockPanel>
                 </Button>
@@ -146,53 +114,34 @@
 
             <!-- Expense Report List -->
             <Rectangle Style="{StaticResource TotalRectangle}" Grid.Row="2" Grid.RowSpan="2" Grid.ColumnSpan="2" />
-            <Grid Style="{StaticResource TotalHeaderGrid}" Grid.Row="2" Grid.ColumnSpan="2">
-
-                <Grid.ToolTip>
-                    <TextBlock>Expense Report</TextBlock>
-                </Grid.ToolTip>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="33*" />
-                    <ColumnDefinition Width="33*" />
-                    <ColumnDefinition Width="33*" />
-                </Grid.ColumnDefinitions>
-
-                <Grid.Background>
-                    <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
-                        <GradientStop Color="#73B2F5" Offset="0" />
-                        <GradientStop Color="#4E87D4" Offset="1" />
-                    </LinearGradientBrush>
-                </Grid.Background>
-
-                <!-- Expense Type Column Header -->
-                <TextBlock Style="{StaticResource TableLabel}" Grid.Column="0">
-                    Expense Type
-                    <TextBlock.ToolTip>
-                        <TextBlock>Expense type</TextBlock>
-                    </TextBlock.ToolTip>
-                </TextBlock>
-
-                <!-- Description Column Header -->
-                <TextBlock Style="{StaticResource TableLabel}" Grid.Column="1">
-                    Description
-                    <TextBlock.ToolTip>
-                        <TextBlock>Desription</TextBlock>
-                    </TextBlock.ToolTip>
-                </TextBlock>
-
-                <!-- Amount Column Header -->
-                <TextBlock Style="{StaticResource TableLabelRightAligned}" Grid.Column="2">
-                    Amount
-                    <TextBlock.ToolTip>
-                        <TextBlock>Amount</TextBlock>
-                    </TextBlock.ToolTip>
-                </TextBlock>
-            </Grid>
-            <ItemsControl Name="expensesItemsControl"
-                          Style="{StaticResource ExpenseScroller}"
-                          Grid.Row="3" Grid.ColumnSpan="2"
-                          ItemTemplate="{StaticResource ExpenseTemplate}"
-                          ItemsSource="{Binding Path=LineItems}" />
+            <DataGrid Style="{DynamicResource DataGridStyle}"
+                          Grid.RowSpan="2"
+                          Grid.Row="2"
+                          Grid.ColumnSpan="2"
+                          Width="Auto"
+                          ColumnWidth="*"
+                          ItemsSource="{Binding LineItems}"
+                          HeadersVisibility="Column"
+                          Name="expenseDataGrid1"
+                          AutoGenerateColumns="False">
+                    <DataGrid.ToolTip>
+                        <TextBlock>Expense Report</TextBlock>
+                    </DataGrid.ToolTip>
+                <DataGrid.Columns>
+                        <DataGridTextColumn Header="Expense type" Binding="{Binding Type}" />
+                        <DataGridTextColumn Header="Description" Binding="{Binding Description}" />
+                        <DataGridTextColumn Header="Cost" CellStyle="{StaticResource RightAlignedCell}" HeaderStyle="{StaticResource RightAlignedColumnHeader}">
+                            <DataGridTextColumn.Binding>
+                                <Binding Path="Cost" UpdateSourceTrigger="PropertyChanged">
+                                    <!-- SECURITY: Cost must be an int -->
+                                    <Binding.ValidationRules>
+                                        <localValidation:NumberValidationRule />
+                                    </Binding.ValidationRules>
+                                </Binding>
+                            </DataGridTextColumn.Binding>
+                        </DataGridTextColumn>
+                    </DataGrid.Columns>
+                </DataGrid>
 
             <!-- Total Expenses -->
             <Rectangle Style="{StaticResource TotalRectangle}" Grid.Row="4" Grid.ColumnSpan="2" />

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/MainWindow.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/MainWindow.xaml
@@ -12,21 +12,12 @@
     WindowStartupLocation="CenterScreen">
 
     <Window.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/ExpenseIt9;component/Styles.xaml">
-                </ResourceDictionary>
-            </ResourceDictionary.MergedDictionaries>
-
             <DataTemplate x:Key="EmployeeItemTemplate">
                 <TextBlock Text="{Binding XPath=@Name}" />
             </DataTemplate>
-
             <DataTemplate x:Key="CostCenterTemplate">
                 <TextBlock Text="{Binding XPath=@Name}" />
             </DataTemplate>
-            
-        </ResourceDictionary>
     </Window.Resources>
 
     <Grid>

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
@@ -90,8 +90,15 @@
         <Setter Property="HorizontalAlignment" Value="Right" />
     </Style>
 
-    <Style x:Key="TotalHeaderGrid" TargetType="{x:Type Grid}">
+    <LinearGradientBrush x:Key="DataGridBackgroundBrush" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="#73B2F5" Offset="0" />
+        <GradientStop Color="#4E87D4" Offset="1" />
+    </LinearGradientBrush>
+
+    <Style x:Key="TotalDataGrid" TargetType="{x:Type DataGrid}">
+        <Setter Property="Background" Value="{StaticResource DataGridBackgroundBrush}"/>
         <Setter Property="Margin" Value="10,10,10,0" />
+        <Setter Property="MaxWidth" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}, Path=RenderSize.Width}" />
     </Style>
 
     <Style x:Key="TotalRectangle" TargetType="{x:Type Rectangle}">
@@ -178,8 +185,6 @@
         </Style.Triggers>
     </Style>
 
-
-
     <Style x:Key="ReadOnlyText" TargetType="{x:Type TextBox}">
         <Setter Property="Margin" Value="0,5,5,0" />
         <Setter Property="IsReadOnly" Value="True" />
@@ -191,8 +196,9 @@
         <Setter Property="MinWidth" Value="80" />
     </Style>
 
-    <Style x:Key="TableLabel" TargetType="{x:Type TextBlock}">
+    <Style x:Key="LeftAlignedColumnHeader" TargetType="{x:Type DataGridColumnHeader}">
         <Setter Property="Foreground" Value="White" />
+        <Setter Property="Background" Value="Transparent" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="FontWeight" Value="Bold" />
@@ -200,8 +206,16 @@
         <Setter Property="Padding" Value="5,0,5,0" />
     </Style>
 
-    <Style x:Key="TableLabelRightAligned" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource TableLabel}">
+    <Style x:Key="RightAlignedColumnHeader" TargetType="{x:Type DataGridColumnHeader}" BasedOn="{StaticResource LeftAlignedColumnHeader}">
         <Setter Property="HorizontalAlignment" Value="Right" />
+    </Style>
+
+    <Style x:Key="RightAlignedCell" TargetType="{x:Type DataGridCell}" >
+        <Setter Property="HorizontalAlignment" Value="Right" />
+    </Style>
+
+    <Style x:Key="DataGridStyle" TargetType="{x:Type DataGrid}" BasedOn="{StaticResource TotalDataGrid}">
+        <Setter Property="ColumnHeaderStyle" Value="{DynamicResource LeftAlignedColumnHeader}" />
     </Style>
 
     <Style x:Key="CommandButtonPanel" TargetType="{x:Type StackPanel}">
@@ -225,20 +239,7 @@
         <Setter Property="Margin" Value="5,10,5,0" />
     </Style>
 
-    <Style x:Key="ExpenseScroller" TargetType="{x:Type ItemsControl}">
-        <Setter Property="Margin" Value="10,0,10,0" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ItemsControl}">
-                    <ScrollViewer VerticalScrollBarVisibility="Auto">
-                        <StackPanel IsItemsHost="True" />
-                    </ScrollViewer>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
-     <Style x:Key="ExpenseChartSmall" TargetType="{x:Type ItemsControl}" BasedOn="{StaticResource ExpenseChart}">
+    <Style x:Key="ExpenseChartSmall" TargetType="{x:Type ItemsControl}" BasedOn="{StaticResource ExpenseChart}">
         <Setter Property="MinWidth" Value="100" />
         <Setter Property="MinHeight" Value="70" />
         <Setter Property="MaxWidth" Value="100" />
@@ -251,37 +252,37 @@
         <Setter Property="Width" Value="40" />
     </Style>
 
-    <Style x:Key="ExpenseRectangle1" TargetType="{x:Type Rectangle}">
+    <Style x:Key="ExpenseRectangleBrackground" TargetType="{x:Type Rectangle}">
         <Setter Property="Margin" Value="10,10,10,0" />
         <Setter Property="Fill" Value="#33000000" />
         <Setter Property="RadiusX" Value="2" />
         <Setter Property="RadiusY" Value="2" />
     </Style>
 
-    <RadialGradientBrush x:Key="brushExpenseRectangle2">
+    <RadialGradientBrush x:Key="BrushForBarsInExpenseChart">
         <GradientStop Color="LimeGreen" Offset="0" />
         <GradientStop Color="DarkGreen" Offset="1" />
     </RadialGradientBrush>
 
-    <Style x:Key="ExpenseRectangle2" TargetType="{x:Type Rectangle}">
+    <Style x:Key="BarsInExpenseChart" TargetType="{x:Type Rectangle}">
         <Setter Property="Margin" Value="10,10,10,0" />
         <Setter Property="Stroke" Value="Black" />
         <Setter Property="StrokeThickness" Value="0.5" />
         <Setter Property="RadiusX" Value="2" />
         <Setter Property="RadiusY" Value="2" />
-        <Setter Property="Fill" Value="{StaticResource brushExpenseRectangle2}"/>
+        <Setter Property="Fill" Value="{StaticResource BrushForBarsInExpenseChart}"/>
     </Style>
 
-    <LinearGradientBrush x:Key="brushExpenseRectangle3" StartPoint="0,0" EndPoint="0,1">
+    <LinearGradientBrush x:Key="BrushExpenseChartRectangle" StartPoint="0,0" EndPoint="0,1">
         <GradientStop Color="#aaffffff" Offset="0" />
         <GradientStop Color="transparent" Offset="1" />
     </LinearGradientBrush>
 
-    <Style x:Key="ExpenseRectangle3" TargetType="{x:Type Rectangle}">
+    <Style x:Key="ExpenseChartRectangle" TargetType="{x:Type Rectangle}">
         <Setter Property="Margin" Value="11,12,11,0" />
         <Setter Property="RadiusX" Value="1" />
         <Setter Property="RadiusY" Value="1" />
-        <Setter Property="Fill" Value="{StaticResource brushExpenseRectangle3}"/>
+        <Setter Property="Fill" Value="{StaticResource BrushExpenseChartRectangle}"/>
     </Style>
 
     <Style x:Key="ExpenseViewbox" TargetType="{x:Type Viewbox}">

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/ViewChartWindow.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/ViewChartWindow.xaml
@@ -6,16 +6,6 @@
         xmlns:local="clr-namespace:ExpenseItDemo"
         mc:Ignorable="d"
         Title="ViewChartWindow" Height="300" Width="300">
-    <Window.Resources>
-
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/ExpenseIt9;component/Styles.xaml">
-                </ResourceDictionary>
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </Window.Resources>
-
     <Grid Style="{StaticResource WindowContentGrid}">
 
         <Grid>


### PR DESCRIPTION
**Previous PRs linked to this:**
**#265  Refactoring styles in sample accessibility apps**
(The apps have been refactored to move styles from within various XAMLs or various controls into a single place called Styles.xaml)

AND 

**#264 ExpenseItDemo: Convert Grid to DataGrid in "Create Expense Report" view**
(Converted Grid to DataGrid to tab out of Expense report neatly by reaching the last cell by pressing CTRL+END
Refactored styles to match new styling for DataGrid
Assigned Access Key to "View Chart" button (#263 )
Linked text boxes to their labels, so that pressing the access keys on these labels will land focus in the text boxes. This is for 3 text boxes in "Create Expense Report" view: (#262 )
Email Alias
Employee Number
Cost Cente)

**Fixes #136 , Fixes #262 , Fixes #263 , Fixes #261** 

**Details:**
- Provided meaningful names for style
- Improved Datagrid refactoring
- Corrected ResourceDictionary usage across apps
 
The sample apps that have been modified are:

ExpenseItIntro (C#)
ExpenseItIntro (VB)
ExpenseItDemo
DataBindingDemo
EditingExaminerDemo
CustomComboBox