### PR TITLE
ExpenseItDemo: Defined label & hint text style for high contrast modes

### DIFF
--- a/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
@@ -180,6 +180,9 @@
                 <Setter Property="ToolTip"
                             Value="{Binding RelativeSource={RelativeSource Self}, Path=ToolTip.Content}" />
             </Trigger>
+            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+            </DataTrigger>
         </Style.Triggers>
     </Style>
 

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
@@ -28,6 +28,11 @@
         <Setter Property="FontWeight" Value="Bold" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalAlignment" Value="Right" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
+                <Setter Property="Label.Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
     </Style>
 
     <Style x:Key="ExpenseChart" TargetType="{x:Type ItemsControl}">


### PR DESCRIPTION
Changed Label style to WindowTextBrushKey when in high contrast

Fixes #220 
Fixes #222 
Fixes #231 
Fixes #233 
Fixes #160 
Fixes #161 
Fixes #162 