### PR TITLE
Fix automation names of items and row generated from XmlDataProvider

### DIFF
--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseItHome.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseItHome.xaml
@@ -76,6 +76,15 @@
                  Grid.Column="1" Grid.Row="2" 
                  ItemsSource="{Binding Source={StaticResource ExpenseDataSource}, XPath=Person}"
                  ItemTemplate="{StaticResource nameItemTemplate}">
+            <ListBox.Resources>
+                <!-- 
+                     When using XmlDataProvider, we need to ensure the ListViewItem properly sets the automation name
+                     instead of using the System.Xml.XmlElement.
+                -->
+                <Style TargetType="{x:Type ListBoxItem}">
+                    <Setter Property="AutomationProperties.Name" Value="{Binding XPath=@Name}"/>
+                </Style>
+            </ListBox.Resources>
         </ListBox>
 
         <!-- View report button -->

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseItHome.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseItHome.xaml
@@ -81,7 +81,7 @@
                      When using XmlDataProvider, we need to ensure the ListViewItem properly sets the automation name
                      instead of using the System.Xml.XmlElement.
                 -->
-                <Style TargetType="{x:Type ListBoxItem}">
+                <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
                     <Setter Property="AutomationProperties.Name" Value="{Binding XPath=@Name}"/>
                 </Style>
             </ListBox.Resources>

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
@@ -63,6 +63,15 @@
 
                 <!-- Expense type and Amount table -->
                 <DataGrid AutomationProperties.Name="Expense report" ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" RowHeaderWidth="0" >
+                    <DataGrid.Resources>
+                        <!--
+                            When using XmlDataProvider, we need to ensure the DataGridRow properly sets the automation name
+                            instead of using the System.Xml.XmlElement.
+                        -->
+                        <Style TargetType="{x:Type DataGridRow}">
+                            <Setter Property="AutomationProperties.Name" Value="DataGrid Row"/>
+                        </Style>
+                    </DataGrid.Resources>
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="ExpenseType" Binding="{Binding XPath=@ExpenseType}"  />
                         <DataGridTextColumn Header="Amount" Binding="{Binding XPath=@ExpenseAmount}" />

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
@@ -68,7 +68,7 @@
                             When using XmlDataProvider, we need to ensure the DataGridRow properly sets the automation name
                             instead of using the System.Xml.XmlElement.
                         -->
-                        <Style TargetType="{x:Type DataGridRow}">
+                        <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource {x:Type DataGridRow}}">
                             <Setter Property="AutomationProperties.Name" Value="DataGrid Row"/>
                         </Style>
                     </DataGrid.Resources>


### PR DESCRIPTION
Fix automation names of generated ListViewItem and DataGridRow so that screen readers report logical values.

Fixes #122 