### PR TITLE
Fix bounding rects in ExpenseItIntro

### DIFF
--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
@@ -62,7 +62,7 @@
             <Grid Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Left">
 
                 <!-- Expense type and Amount table -->
-                <DataGrid AutomationProperties.Name="Expense report" ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" RowHeaderWidth="0" >
+                <DataGrid AutomationProperties.Name="Expense report" ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" RowHeaderWidth="0" CanUserResizeColumns="False" CanUserResizeRows="False" >
                     <DataGrid.Resources>
                         <!--
                             When using XmlDataProvider, we need to ensure the DataGridRow properly sets the automation name
@@ -73,7 +73,7 @@
                         </Style>
                     </DataGrid.Resources>
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="ExpenseType" Binding="{Binding XPath=@ExpenseType}"  />
+                        <DataGridTextColumn Header="ExpenseType" Binding="{Binding XPath=@ExpenseType}" />
                         <DataGridTextColumn Header="Amount" Binding="{Binding XPath=@ExpenseAmount}" />
                     </DataGrid.Columns>
                 </DataGrid>


### PR DESCRIPTION
Turn off resizing so 0-size bounding rects for resize thumbs in datagrid are marked offscreen.

Fixes #153