### PR TITLE
Enable sdk override

### DIFF
--- a/Accessibility/FindText/FindTextClient/FindTextClient.csproj
+++ b/Accessibility/FindText/FindTextClient/FindTextClient.csproj
@@ -87,6 +87,7 @@
     <ProjectReference Include="..\FindText\FindText.csproj">
       <Project>{117631d2-3687-49d6-bd15-7b9a21b4399a}</Project>
       <Name>FindText</Name>
+      <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Accessibility/InsertText/InsertTextClient/InsertTextClient.csproj
+++ b/Accessibility/InsertText/InsertTextClient/InsertTextClient.csproj
@@ -107,6 +107,7 @@
     <ProjectReference Include="..\InsertTextTarget\InsertTextTarget.csproj">
       <Project>{22788661-2cbc-4933-b031-4817cbce6c89}</Project>
       <Name>InsertTextTarget</Name>
+      <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Accessibility/InvokePattern/InvokePatternApp/InvokePatternApp.csproj
+++ b/Accessibility/InvokePattern/InvokePatternApp/InvokePatternApp.csproj
@@ -88,6 +88,7 @@
     <ProjectReference Include="..\Target\Target.csproj">
       <Project>{d8d81cbf-c254-42d6-bba3-5a32150b70f1}</Project>
       <Name>Target</Name>
+      <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Accessibility/SelectionPattern/SelectionPatternSample/SelectionPatternSample.csproj
+++ b/Accessibility/SelectionPattern/SelectionPatternSample/SelectionPatternSample.csproj
@@ -107,6 +107,7 @@
     <ProjectReference Include="..\SelectionTarget\SelectionTarget.csproj">
       <Project>{0755f6c3-3fa5-4410-b0d0-4034c64cc138}</Project>
       <Name>SelectionTarget</Name>
+      <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Application Management/CustomApplication/CustomApplicationClass/CustomApplicationClass.csproj
+++ b/Application Management/CustomApplication/CustomApplicationClass/CustomApplicationClass.csproj
@@ -83,6 +83,7 @@
     <ProjectReference Include="..\CustomApplicationClient\CustomApplicationClient.csproj">
       <Project>{2e41b158-06cb-4f09-b2a8-67394c3fd22a}</Project>
       <Name>CustomApplicationClient</Name>
+      <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
 

--- a/Input and Commands/TouchKeyboard/TouchKBRegister/TouchKBRegister.csproj
+++ b/Input and Commands/TouchKeyboard/TouchKBRegister/TouchKBRegister.csproj
@@ -135,6 +135,7 @@
     <ProjectReference Include="..\TouchKeyboardNotifier\TouchKeyboardNotifier.csproj">
       <Project>{b4c448d1-8853-4738-99e0-fab7c7a63314}</Project>
       <Name>TouchKeyboardNotifier</Name>
+      <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Migration and Interoperability/HWNDInWPF/wpfapplication1/wpfapplication1.csproj
+++ b/Migration and Interoperability/HWNDInWPF/wpfapplication1/wpfapplication1.csproj
@@ -35,7 +35,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\hwndinwpf\hwndInWPF.vcxproj" />
+    <ProjectReference Include="..\hwndinwpf\hwndInWPF.vcxproj">
+      <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="MyApp.xaml">

--- a/Migration and Interoperability/WPFUserControlHost/WPFUserControlHost.csproj
+++ b/Migration and Interoperability/WPFUserControlHost/WPFUserControlHost.csproj
@@ -81,6 +81,7 @@
     <ProjectReference Include="..\HostingWpfUserControlInWf\HostingWpfUserControlInWf.csproj">
       <Project>{158d6826-38d9-49b0-a6ca-a46df7be03e3}</Project>
       <Name>HostingWpfUserControlInWf</Name>
+      <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Migration and Interoperability/WindowsFormsHostingWpfControl/FormsApp/FormsApp.csproj
+++ b/Migration and Interoperability/WindowsFormsHostingWpfControl/FormsApp/FormsApp.csproj
@@ -86,6 +86,7 @@
     <ProjectReference Include="..\WPFControls\WPFControls.csproj">
       <Project>{27e26a5c-1333-44ff-81dc-dd4db0bfc313}</Project>
       <Name>WPFControls</Name>
+      <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Migration and Interoperability/WpfHostingWindowsFormsControl/WPFApp/WPFApp.csproj
+++ b/Migration and Interoperability/WpfHostingWindowsFormsControl/WPFApp/WPFApp.csproj
@@ -103,6 +103,7 @@
     <ProjectReference Include="..\FormsControlLibrary\FormsControlLibrary.csproj">
       <Project>{dafd8300-8a73-4e07-8480-695c14b491e0}</Project>
       <Name>FormsControlLibrary</Name>
+      <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/ExpenseItDemo.csproj
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/ExpenseItDemo.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\EditBoxControlLibrary\EditBoxControlLibrary.csproj">
       <Project>{558eee03-6927-4fe6-aeb6-972769960849}</Project>
       <Name>EditBoxControlLibrary</Name>
+      <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
     </ProjectReference>
     <Resource Include="Watermark.png" />
   </ItemGroup>

--- a/Tools/BamlReflector/BamlReflector/BamlReflector.csproj
+++ b/Tools/BamlReflector/BamlReflector/BamlReflector.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <ProjectReference Include="..\BamlTools\BamlTools.csproj" />
+    <ProjectReference Include="..\BamlTools\BamlTools.csproj">
+      <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
+    </ProjectReference>
   </ItemGroup>  
 </Project>

--- a/eng/EnsureGlobalJsonSdk.ps1
+++ b/eng/EnsureGlobalJsonSdk.ps1
@@ -19,7 +19,15 @@ param(
   [string] [Alias('f')]
   [Parameter(HelpMessage='TargetFramework to match from global.json/altsdk section for an alternate SDK version')]
   [ValidateSet('', $null, 'netcoreapp3.1', 'netcoreapp5.0', IgnoreCase=$true)]
-  $TargetFramework=''
+  $TargetFramework='',
+
+  [string]
+  [Parameter(HelpMessage='SDK Override Version')]
+  $SdkVersionOverride = $null,
+
+  [string[]]
+  [Parameter(HelpMessage='Additional NuGet Feeds for Overridden SDK Version')]
+  $AdditionalNuGetFeeds = $null
 )
 
 Function IIf($If, $Then, $Else) {
@@ -122,6 +130,12 @@ if (Test-Path $globalJson) {
         }
     }
 
+    if ($SdkVersionOverride) {
+        Write-Verbose "SdkVersionOverride=$SdkVersionOverride - overriding"
+        $sdk_version = $SdkVersionOverride
+    }
+
+
     if ($sdk_version) {
         $dotnet_install = "$env:TEMP\dotnet-install.ps1"
 
@@ -153,7 +167,7 @@ if (Test-Path $globalJson) {
             This is a destructive change. The global.json should be restored by doing this after a build:
                     git checkout global.json
         #>
-        if ($TargetFramework) {
+        if ($TargetFramework -or $SdkVersionOverride) {
             <# 
                 We would like to use '$dotnet new globaljson --sdk-version $sdk_version --force', but,...
                 ..when global.json has a sdk.version that's different from the sdk installed, dotnet.exe complains:
@@ -166,6 +180,29 @@ if (Test-Path $globalJson) {
             $json | ConvertTo-Json | Set-Content $globalJson -Force
             Write-Verbose "global.json updated"
             Write-Verbose (Get-Content $globalJson -Raw)
+        }
+
+        if ($SdkVersionOverride -and $AdditionalNuGetFeeds) {
+            $nugetConfig = Join-Path (Get-Item $globalJson).Directory.FullName 'NuGet.config'
+            if (Test-Path $nugetConfig) {
+                Write-Verbose "Additional Feeds requested - Updating NuGet.config"
+                Write-Verbose "Feeds are..."
+                $AdditionalNuGetFeeds | %{
+                    $feed = $_
+                    Write-Verbose "`t$feed"
+                }
+
+                # Download NuGet.exe 
+                $NuGetExe = join-path $env:TEMP 'nuget.exe'
+                if (-not (Test-Path $NuGetExe -PathType Leaf)) {
+                    Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile $NuGetExe
+                    Write-Verbose "Downloaded nuget.exe to $NuGetExe"
+                }
+
+                for ($i = 0; $i -lt $AdditionalNuGetFeeds.Count; $i++) {
+                    & $NuGetExe Sources Add -Name "transient-delete-$i" -Source $AdditionalNuGetFeeds[$i]
+                }
+            }
         }
     }
 }

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -236,7 +236,10 @@ Function Start-VsDevCmd {
     if ($installationPath -and (test-path "$installationPath\Common7\Tools\vsdevcmd.bat")) {
         & "${env:COMSPEC}" /s /c "`"$installationPath\Common7\Tools\vsdevcmd.bat`" -no_logo && set" | foreach-object {
             $name, $value = $_ -split '=', 2
-            set-content env:\"$name" $value
+            Write-Verbose "Setting env:$name=$value"
+            if ($name -and $value) {
+                set-content env:\"$name" "$value"
+            }
         }
     }
 }
@@ -456,4 +459,3 @@ Finally {
         Copy-Item (Join-Path $ArtifactsTemp 'NuGet.config') $NuGetConfig -Force
     }
 }
-

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -296,6 +296,8 @@ Function Get-BuildArgs {
         $BuildArgs += " /m"
         if ($Restore) {
             $BuildArgs += " /t:restore"
+        } else {
+            $BuildArgs += " /t:publish"
         }
     }
     

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -316,8 +316,9 @@ Function Ensure-Directory {
 
 ###################### Start of main script #########################
 
-$AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
-[System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
+# Chocolatey requires min TLS1.2
+# https://chocolatey.org/blog/remove-support-for-old-tls-versions
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
 if ($psISE) {
     $Eng =  (Get-Item (Split-Path $psISE.CurrentFile.FullPath -Parent)).FullName

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -343,7 +343,7 @@ $MsBuildOnlySolution = Join-Path $RepoRoot 'WPFSamples.msbuild.sln'
 
 $EnsureGlobalJsonSdk = Join-Path $Eng 'EnsureGlobalJsonSdk.ps1'
 
-if (-not [string]::IsNullOrEmpty($TargetFramework)) {
+if ([string]::IsNullOrEmpty($TargetFramework)) {
     if (-not $SdkVersionOverride) {
         $json = (Get-Content $GlobalJson | ConvertFrom-Json)
         $TargetFramework = Get-Tfm $json.sdk.version

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -312,6 +312,11 @@ Function Ensure-Directory {
     }
 }
 
+###################### Start of main script #########################
+
+$AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
+[System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
+
 if ($psISE) {
     $Eng =  (Get-Item (Split-Path $psISE.CurrentFile.FullPath -Parent)).FullName
 } else {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -278,7 +278,7 @@ Function Get-BuildArgs {
     $LangVersion = 'latest'
     
     if (-not $Restore) {
-        $BuildArgs = "$escapeparser /bl:$LogFile /p:Platform=$Platform /p:LangVersion=$LangVersion /p:PublishDir=$PublishDir /p:RuntimeIdentifier=$RuntimeIdentifier /clp:Summary;Verbosity=$Verbosity /nr:$NodeReuse"
+        $BuildArgs = "$escapeparser /bl:$LogFile /p:Platform=$Platform /p:LangVersion=$LangVersion /p:PublishDir=$PublishDir /p:UseCommonOutputDirectory=true /p:RuntimeIdentifier=$RuntimeIdentifier /clp:Summary;Verbosity=$Verbosity /nr:$NodeReuse"
     } else {
         $BuildArgs = "$escapeparser /bl:$RestoreLogFile /p:RuntimeIdentifier=$RuntimeIdentifier /clp:Summary;Verbosity=$Verbosity /nr:$NodeReuse"
     }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "3.1.102",
-	"rollForward": "latestPatch"
+    "rollForward": "latestPatch"
   },
   "altsdk": {
     "netcoreapp3.1": "3.1.102",


### PR DESCRIPTION
- Enable support for building with a specific version of the SDK
- Update `global.json` to `3.1.102` and apply `rollForward `policy (see #284,) 
- Set `UseCommonOutputDirectory=true` to improve build perf

/cc @rladuca 