### PR TITLE
[Fix] Fixed sdk option to support more wide sdk version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "3.1.102",
-    "rollForward": "latestPatch"
+    "rollForward": "latestMajor"
   },
   "altsdk": {
     "netcoreapp3.1": "3.1.102",


### PR DESCRIPTION
- In case of installing latest sdk version(e.g 3.1.200) , all the project  was failed to load .

- The value of "rollForward' might be "latestMajor" not "latestPatch" as supporting variety of sdk environment.

- ref. https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?tabs=netcore3x#rollforward

@vatsan-madhavan 

Signed-off-by: Harry Hyeongseok Heo <legume1@gmail.com>