### PR TITLE
Support for net5.0 TFM

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -11,5 +11,6 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-wd" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
     <add key="aspnet-core" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
+	<add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,60 +42,60 @@ stages:
         _Platform: 'Any CPU'
         _TargetFramework: 'netcoreapp3.1'
         _ToolPlatform: x86
-      Debug-AnyCPU-netcoreapp5.0:
+      Debug-AnyCPU-net5.0:
         _Configuration: Debug
         _Platform: 'Any CPU'
-        _TargetFramework: 'netcoreapp5.0'
+        _TargetFramework: 'net5.0'
         _ToolPlatform: x86
       Debug-x64-netcoreapp3.1:
         _Configuration: Debug
         _Platform: 'x64'
         _TargetFramework: 'netcoreapp3.1'
         _ToolPlatform: x64
-      Debug-x64-netcoreapp5.0:
+      Debug-x64-net5.0:
         _Configuration: Debug
         _Platform: 'x64'
-        _TargetFramework: 'netcoreapp5.0'
+        _TargetFramework: 'net5.0'
         _ToolPlatform: x64
       Debug-x86-netcoreapp3.1:
         _Configuration: Debug
         _Platform: 'x86'
         _TargetFramework: 'netcoreapp3.1'
         _ToolPlatform: x86
-      Debug-x86-netcoreapp5.0:
+      Debug-x86-net5.0:
         _Configuration: Debug
         _Platform: 'x86'
-        _TargetFramework: 'netcoreapp5.0'
+        _TargetFramework: 'net5.0'
         _ToolPlatform: x86
       Release-AnyCPU-netcoreapp3.1:
         _Configuration: Release
         _Platform: 'Any CPU'
         _TargetFramework: 'netcoreapp3.1'
         _ToolPlatform: x86
-      Release-AnyCPU-netcoreapp5.0:
+      Release-AnyCPU-net5.0:
         _Configuration: Release
         _Platform: 'Any CPU'
-        _TargetFramework: 'netcoreapp5.0'
+        _TargetFramework: 'net5.0'
         _ToolPlatform: x86
       Release-x64-netcoreapp3.1:
         _Configuration: Release
         _Platform: 'x64'
         _TargetFramework: 'netcoreapp3.1'
         _ToolPlatform: x64
-      Release-x64-netcoreapp5.0:
+      Release-x64-net5.0:
         _Configuration: Release
         _Platform: 'x64'
-        _TargetFramework: 'netcoreapp5.0'
+        _TargetFramework: 'net5.0'
         _ToolPlatform: x64
       Release-x86-netcoreapp3.1:
         _Configuration: Release
         _Platform: 'x86'
         _TargetFramework: 'netcoreapp3.1'
         _ToolPlatform: x86
-      Release-x86-netcoreapp5.0:
+      Release-x86-net5.0:
         _Configuration: Release
         _Platform: 'x86'
-        _TargetFramework: 'netcoreapp5.0'
+        _TargetFramework: 'net5.0'
         _ToolPlatform: x86
     steps:
      - task: NuGetToolInstaller@1

--- a/eng/AzurePipelinesMatrixGenerator.ps1
+++ b/eng/AzurePipelinesMatrixGenerator.ps1
@@ -7,7 +7,7 @@ Function IIf($If, $Then, $Else) {
 
 $config = @('Debug', 'Release')
 $platform = @('Any CPU', 'x86', 'x64')
-$tfm = @('netcoreapp3.1', 'netcoreapp5.0')
+$tfm = @('netcoreapp3.1', 'net5.0')
 
 $entries = @{}
 

--- a/eng/EnsureGlobalJsonSdk.ps1
+++ b/eng/EnsureGlobalJsonSdk.ps1
@@ -18,7 +18,7 @@ param(
 
   [string] [Alias('f')]
   [Parameter(HelpMessage='TargetFramework to match from global.json/altsdk section for an alternate SDK version')]
-  [ValidateSet('', $null, 'netcoreapp3.1', 'netcoreapp5.0', IgnoreCase=$true)]
+  [ValidateSet('', $null, 'netcoreapp3.1', 'net5.0', IgnoreCase=$true)]
   $TargetFramework='',
 
   [string]
@@ -49,12 +49,13 @@ Function Get-Tfm {
         'netcoreapp2.2',
         'netcoreapp3.0',
         'netcoreapp3.1',
-        'netcoreapp5.0'
+        'net5.0'
     )
 
-    $tfm = ('netcoreapp' + $SdkVersion.Substring(0,3)).Trim().ToLowerInvariant()
+    $tfm1 = ('netcoreapp' + $SdkVersion.Substring(0,3)).Trim().ToLowerInvariant()
+	$tfm2 = ('net' + $SdkVersion.Substring(0,3)).Trim().ToLowerInvariant()
 
-    return IIf ($WellKnownTFMs -icontains $tfm) $tfm ""
+    return IIf (($WellKnownTFMs -icontains $tfm1) -or ($WellKnownTFMs -icontains $tfm2)) $tfm ""
 }
 
 function Add-EnvPath {

--- a/eng/README.md
+++ b/eng/README.md
@@ -1,72 +1,74 @@
-```
+# Build Script
+
+```none
 NAME
     build.ps1
-    
+
 SYNOPSIS
     Builds and publishes the projects
-    
-    
+
+
 SYNTAX
     build.ps1 [-Architecture <String>] [-Configuration <String>] [-TargetFramework <String>] [-DryRun] [-UseMsBuild] [<CommonParameters>]
-    
-    
+
+
 DESCRIPTION
     Builds and publishes the projects under artifacts\. Provides control over what TargetFramework to build against,
     which build engine to use (dotnet vs. MSBuild), and what architecture (x86, x64) to build.
-    
+
 
 PARAMETERS
     -Architecture <String>
-        The Platform architecture to build. 
-        Valid values are AnyCPU, 'Any CPU', x86, Win32, x64, and amd64. 
-        
+        The Platform architecture to build.
+        Valid values are AnyCPU, 'Any CPU', x86, Win32, x64, and amd64.
+
         The default is $env:PROCESSOR_ARCHITECTURE, i.e., the architecture of the current
-        OS. 
-        
-        amd64 is equivalent to x64 
+        OS.
+
+        amd64 is equivalent to x64
         AnyCPU and 'Any CPU' and Win32 are equivalent to x86
-        
+
     -Configuration <String>
         The build configuration
-        
+
         Valid values are Debug, Release
         The default is Debug
-        
+
     -TargetFramework <String>
-        The TargetFramework to build for. 
-        
-        This will always default to the most recent released version of .NET Core that supports WPF. 
-        You can identify this by loking at global.json sdk.version property, or <TargetFramework> property 
-        in project files im this repo. 
-        
+        The TargetFramework to build for.
+
+        This will always default to the most recent released version of .NET Core that supports WPF.
+        You can identify this by loking at global.json sdk.version property, or <TargetFramework> property
+        in project files im this repo.
+
         Alternative TargetFramework can be supplied to build. Currently, netcoreapp3.1 (default),
-        and netcoreapp5.0 are supported.
-        
+        and net5.0 are supported.
+
     -DryRun [<SwitchParameter>]
         When this switch is specified, the build is simulated, but the actual build is not run.
-        
+
     -UseMsBuild [<SwitchParameter>]
-        When this switch is specified, MSBuild is used as the build engine instead of dotnet.exe. 
-        This requires that VS2019 be installed and avaialble on the local machine. 
-        
+        When this switch is specified, MSBuild is used as the build engine instead of dotnet.exe.
+        This requires that VS2019 be installed and avaialble on the local machine.
+
         Some projects in this repo can be built only using MSBuild.
-        
+
     <CommonParameters>
         This cmdlet supports the common parameters: Verbose, Debug,
         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-        OutBuffer, PipelineVariable, and OutVariable. For more information, see 
-        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216). 
-    
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
+
     -------------------------- EXAMPLE 1 --------------------------
     PS C:\>build.ps1
-    
+
     Builds the repo
     -------------------------- EXAMPLE 2 --------------------------
-    PS C:\>build.ps1 -TargetFramework netcoreapp5.0 -UseMsBuild
-    
-    Builds the repo using MSBuild for netcoreapp5.0 TFM
+    PS C:\>build.ps1 -TargetFramework net5.0 -UseMsBuild
+
+    Builds the repo using MSBuild for net5.0 TFM
     -------------------------- EXAMPLE 3 --------------------------
     PS C:\>build.ps1 -UseMsBuild -Platform x86 -Configuration Release
-    
+
     Builds the repo using MSBuild for x86 platform & Release configuration
 ```

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -26,7 +26,7 @@
     in project files im this repo. 
     
     Alternative TargetFramework can be supplied to build. Currently, netcoreapp3.1 (default),
-    and netcoreapp5.0 are supported.
+    and net5.0 are supported.
 .PARAMETER DryRun 
     When this switch is specified, the build is simulated, but the actual build is not run. 
 .PARAMETER UseMsBuild 
@@ -44,9 +44,9 @@
     build.ps1
     Builds the repo 
 .EXAMPLE 
-    build.ps1 -TargetFramework netcoreapp5.0 -UseMsBuild
+    build.ps1 -TargetFramework net5.0 -UseMsBuild
     
-    Builds the repo using MSBuild for netcoreapp5.0 TFM 
+    Builds the repo using MSBuild for net5.0 TFM 
 .EXAMPLE 
     build.ps1 -UseMsBuild -Platform x86 -Configuration Release
     
@@ -66,7 +66,7 @@ param(
 
   [string] [Alias('f')]
   [Parameter(HelpMessage='TargetFramework to match from global.json/altsdk section for an alternate SDK version')]
-  [ValidateSet('', $null, 'netcoreapp3.1', 'netcoreapp5.0', IgnoreCase=$true)]
+  [ValidateSet('', $null, 'netcoreapp3.1', 'net5.0', IgnoreCase=$true)]
   $TargetFramework='', 
 
   [switch]
@@ -172,12 +172,13 @@ Function Get-Tfm {
         'netcoreapp2.2',
         'netcoreapp3.0',
         'netcoreapp3.1',
-        'netcoreapp5.0'
+        'net5.0'
     )
 
-    $tfm = ('netcoreapp' + $SdkVersion.Substring(0,3)).Trim().ToLowerInvariant()
+    $tfm1 = ('netcoreapp' + $SdkVersion.Substring(0,3)).Trim().ToLowerInvariant()
+	$tfm2 = ('net' + $SdkVersion.Substring(0,3)).Trim().ToLowerInvariant()
 
-    return IIf ($WellKnownTFMs -icontains $tfm) $tfm ""
+    return IIf (($WellKnownTFMs -icontains $tfm1) -or ($WellKnownTFMs -icontains $tfm2)) $tfm ""
 }
 
 Function Identify-RID {
@@ -207,7 +208,7 @@ Function Get-VsWhere {
 
     if (-not (Test-Path $VsWhere)) {
         # Try again
-        Uninstall-Package -ProviderName Chocolatey -Name vswhere -Force
+        Uninstall-Package -ProviderName Chocolatey -Name vswhere -Force -ErrorAction SilentlyContinue
         Install-Package -ProviderName Chocolatey -Name vswhere -Force
         if (-not (Test-Path $VsWhere)) {
             # Let's try something else 

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "3.1.102",
+    "version": "3.1.301",
     "rollForward": "latestFeature"
   },
   "altsdk": {
-    "netcoreapp3.1": "3.1.102",
-    "netcoreapp5.0": "5.0.100-alpha1-015754"
+    "netcoreapp3.1": "3.1.300",
+    "net5.0": "5.0.100-preview.6.20309.4"
   }
 }


### PR DESCRIPTION
Adds support for net5.0 TFM in PR pipelines. It used to support netcoreapp5.0, which is no longer a valid TFM. 

Support for net5.0-windows can't be enabled just yet because it doesn't exist in the preview SDK's. 

/cc @ryalanms 