### PR TITLE
Fix for 1144894 remove confusing keyboard-focus behavior in CustomComboBox sample

### DIFF
--- a/Sample Applications/CustomComboBox/MainWindow.xaml
+++ b/Sample Applications/CustomComboBox/MainWindow.xaml
@@ -19,7 +19,8 @@
                              HorizontalAlignment="Center" VerticalAlignment="Top"
                              Style="{StaticResource DropListStyle}" 
                              ItemsSource="{Binding Movies}" Command="{Binding OnWatchNow}" 
-                             DisplayMemberPath="Title"/>
+                             DisplayMemberPath="Title"
+                             IsTabStop="False"/>
 
         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
             <TextBlock Text="{Binding SelectedMovie, Converter={StaticResource stringConverter}, ConverterParameter=text}" Style="{DynamicResource streamingTextStyle}"/>


### PR DESCRIPTION
As there is no keyboard action for the control as a whole, having it be a tabstop is confusing.  