### PR TITLE
Fix 1144932 by in ComboBoxSample by setting the tab-order to the logical order of operations

### DIFF
--- a/Sample Applications/CustomComboBox/Styles.xaml
+++ b/Sample Applications/CustomComboBox/Styles.xaml
@@ -247,7 +247,7 @@
                                     <ColumnDefinition/>
                                 </Grid.ColumnDefinitions>
                                 <ToggleButton FocusVisualStyle="{DynamicResource CustomFocusVisual}"
-                                              AutomationProperties.Name="Play">
+                                              AutomationProperties.Name="Play" TabIndex="0">
                                     <ToggleButton.Template>
                                         <ControlTemplate TargetType="ToggleButton">
                                             <Border Background="Transparent">
@@ -294,7 +294,7 @@
                                 <Grid Grid.Column="2" Height="37">
                                     <Button AutomationProperties.Name="Watch Now"  FocusVisualStyle="{DynamicResource CustomFocusVisual}" Command="{Binding Command, RelativeSource={RelativeSource TemplatedParent}}" 
                                                 CommandParameter="{Binding ElementName=lstBx, Path=SelectedItem}" 
-                                                Content="{TemplateBinding Content}">
+                                                Content="{TemplateBinding Content}" TabIndex="2">
                                         <Button.Template>
                                             <ControlTemplate TargetType="Button">
                                                 <Border CornerRadius="4">
@@ -331,7 +331,8 @@
                                      FocusVisualStyle="{DynamicResource CustomFocusVisual}"
                                      ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ItemsSource}"
                                      DisplayMemberPath="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMemberPath}" 
-                                     SelectedValuePath="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMemberPath}">
+                                     SelectedValuePath="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMemberPath}"
+                                     TabIndex="1">
                             <ListBox.Resources>
                                 <Style TargetType="ScrollBar" BasedOn="{StaticResource ScrollBarStyle}" />
                                 <Style TargetType="ListBoxItem" BasedOn="{StaticResource ListBoxItemStyle}" />


### PR DESCRIPTION
Set a tab order in ComboBoxSample to match the logical order of operations

Previous behavior:
Tab focus does not go to the list of movies after expanding the button.
While navigating through tab key, Keyboard focus goes illogical that after selection of movie, the tab focus does not go to the watch now button.

New behavior:
Keyboard tab focus goes to the watch now button after selecting any movie from the list.
Tab focus should go to the movies list and after expanding the button and then from the list it should go to the watch now button.
Expand button-->Movies list-->Watch Now button.