### PR TITLE
Fix for 1145048 -- ensure that focus rectangle is visible

### DIFF
--- a/Sample Applications/EditingExaminerDemo/MainWindow.xaml
+++ b/Sample Applications/EditingExaminerDemo/MainWindow.xaml
@@ -22,130 +22,132 @@
                     <StackPanel />
                 </TabItem>
                 <TabItem Header="Help" AutomationProperties.Name="Help" AutomationProperties.HelpText="Help Tab: The content in this tab explains how to use the demo.">
-                    <FlowDocumentScrollViewer Margin="10" Style="{StaticResource ScrollViewer}">
-                        <FlowDocument
-                            ColumnWidth="400" AutomationProperties.Name="Help Text"
-                            IsOptimalParagraphEnabled="True" IsHyphenationEnabled="True">
-                            <Section FontSize="12">
-                                <Paragraph FontSize="22" FontWeight="Bold">Introducing Editing Examiner</Paragraph>
+                    <Border BorderThickness="1" BorderBrush="Black">
+                        <FlowDocumentScrollViewer Margin="1">
+                            <FlowDocument
+                                ColumnWidth="400" AutomationProperties.Name="Help Text"
+                                IsOptimalParagraphEnabled="True" IsHyphenationEnabled="True">
+                                <Section FontSize="12">
+                                    <Paragraph FontSize="22" FontWeight="Bold">Introducing Editing Examiner</Paragraph>
 
-                                <Paragraph>
-                                    Editing Examiner lets you watch in real time as edits are performed within a
-                                    RichTextBox control. It allows the user to load or partially insert XAML into a document by using the core parser
-                                    or the editing parser. In addition, it provides basic support for invoking methods, as well as getting and setting
-                                    properties. This tool is useful for examining the editing status of a Document from different
-                                    perspectives.
-                                </Paragraph>
+                                    <Paragraph>
+                                        Editing Examiner lets you watch in real time as edits are performed within a
+                                        RichTextBox control. It allows the user to load or partially insert XAML into a document by using the core parser
+                                        or the editing parser. In addition, it provides basic support for invoking methods, as well as getting and setting
+                                        properties. This tool is useful for examining the editing status of a Document from different
+                                        perspectives.
+                                    </Paragraph>
 
-                                <Paragraph FontSize="18" FontWeight="Bold">Application Features</Paragraph>
-                                <Paragraph FontSize="15" FontWeight="Bold">DocumentTree Tab</Paragraph>
-                                <Paragraph>
-                                    The DocumentTree Tab displays the entire TreeView of the document container. It demonstrates how to use the
-                                    TextElementCollection features. It updates automatically on each TextChanged event of the RichTextBox.
-                                    This allows you to visualize the document hierarchy.
-                                </Paragraph>
+                                    <Paragraph FontSize="18" FontWeight="Bold">Application Features</Paragraph>
+                                    <Paragraph FontSize="15" FontWeight="Bold">DocumentTree Tab</Paragraph>
+                                    <Paragraph>
+                                        The DocumentTree Tab displays the entire TreeView of the document container. It demonstrates how to use the
+                                        TextElementCollection features. It updates automatically on each TextChanged event of the RichTextBox.
+                                        This allows you to visualize the document hierarchy.
+                                    </Paragraph>
 
-                                <Paragraph FontSize="15" FontWeight="Bold">TextSerializedXaml Tab</Paragraph>
+                                    <Paragraph FontSize="15" FontWeight="Bold">TextSerializedXaml Tab</Paragraph>
 
-                                <Paragraph>
-                                    By clicking on the Text Serialization tab, the underlying XAML is exposed, using WPF serialization
-                                    features. The TreeView is instantly updated when the Tab is selected. You can edit your XAML content
-                                    and set it back to the RichTextBox by right clicking and selecting the correct item.
-                                </Paragraph>
+                                    <Paragraph>
+                                        By clicking on the Text Serialization tab, the underlying XAML is exposed, using WPF serialization
+                                        features. The TreeView is instantly updated when the Tab is selected. You can edit your XAML content
+                                        and set it back to the RichTextBox by right clicking and selecting the correct item.
+                                    </Paragraph>
 
-                                <Paragraph FontSize="15" FontWeight="Bold">SelectionXAML Tab</Paragraph>
+                                    <Paragraph FontSize="15" FontWeight="Bold">SelectionXAML Tab</Paragraph>
 
-                                <Paragraph>
-                                    This tab displays the underlying XAML of the selected content within the RichTextBox.
-                                </Paragraph>
+                                    <Paragraph>
+                                        This tab displays the underlying XAML of the selected content within the RichTextBox.
+                                    </Paragraph>
 
-                                <Paragraph FontSize="15" FontWeight="Bold">CoreXAML Tab:</Paragraph>
+                                    <Paragraph FontSize="15" FontWeight="Bold">CoreXAML Tab:</Paragraph>
 
-                                <Paragraph>
-                                    This tab accesses the WPF core parser in order to parse an object. The object can then be inserted
-                                    back into the RichTextBox. Alternately you can use this view to see how the RichTextBox content is
-                                    serialized back to XAML.
-                                </Paragraph>
+                                    <Paragraph>
+                                        This tab accesses the WPF core parser in order to parse an object. The object can then be inserted
+                                        back into the RichTextBox. Alternately you can use this view to see how the RichTextBox content is
+                                        serialized back to XAML.
+                                    </Paragraph>
 
 
-                                <Paragraph FontSize="15" FontWeight="Bold">Immediate Window:</Paragraph>
+                                    <Paragraph FontSize="15" FontWeight="Bold">Immediate Window:</Paragraph>
 
-                                <Paragraph>
-                                    This provides an instant way to invoke methods, and get or set properties.
+                                    <Paragraph>
+                                        This provides an instant way to invoke methods, and get or set properties.
 
-                                </Paragraph>
-                                <List MarkerOffset="25" MarkerStyle="Disc">
-                                    <ListItem>
-                                        <Paragraph>The lower input box (labeled "Type Command here!" is for command input.</Paragraph>
-                                    </ListItem>
-                                    <ListItem>
-                                        <Paragraph>The upper TextBox (readonly) displays the output and command history.</Paragraph>
-                                    </ListItem>
-                                    <ListItem>
-                                        <Paragraph>The {Enter} key is the only trigger for starting invoke operations.</Paragraph>
-                                    </ListItem>
-                                    <ListItem>
-                                        <Paragraph>Object creation is supported by invoking a constructor.</Paragraph>
-                                    </ListItem>
-                                    <ListItem>
-                                        <Paragraph>
-                                            You can save (declare) an object and use it later. For example:
-                                            <Run FontFamily="Courier New" xml:space="preserve">
+                                    </Paragraph>
+                                    <List MarkerOffset="25" MarkerStyle="Disc">
+                                        <ListItem>
+                                            <Paragraph>The lower input box (labeled "Type Command here!" is for command input.</Paragraph>
+                                        </ListItem>
+                                        <ListItem>
+                                            <Paragraph>The upper TextBox (readonly) displays the output and command history.</Paragraph>
+                                        </ListItem>
+                                        <ListItem>
+                                            <Paragraph>The {Enter} key is the only trigger for starting invoke operations.</Paragraph>
+                                        </ListItem>
+                                        <ListItem>
+                                            <Paragraph>Object creation is supported by invoking a constructor.</Paragraph>
+                                        </ListItem>
+                                        <ListItem>
+                                            <Paragraph>
+                                                You can save (declare) an object and use it later. For example:
+                                                <Run FontFamily="Courier New" xml:space="preserve">
                         
 Box = new TextBox();
 Box.Text="some text";
 RichTextBox.Selection.Text = Box.Text;
-                    </Run>
-                                        </Paragraph>
-                                    </ListItem>
-                                    <ListItem>
-                                        <Paragraph>
-                                            You can also perform complicated object invocation such as the following:
-                                            <Run FontFamily="Courier New" xml:space="preserve">
+                        </Run>
+                                            </Paragraph>
+                                        </ListItem>
+                                        <ListItem>
+                                            <Paragraph>
+                                                You can also perform complicated object invocation such as the following:
+                                                <Run FontFamily="Courier New" xml:space="preserve">
                         
 Document.Blocks.Add(new Paragraph(new Run("add Paragraph")));
 RichTextBox.FlowDirection = FlowDirection.RightToLeft;
-                      </Run>
-                                        </Paragraph>
-                                    </ListItem>
-                                    <ListItem>
-                                        <Paragraph>
-                                            The command input box is actually an editable ComboBox. It provides a string search function.
-                                            It tries to be smart as a user is typing. It helps to search the property (or fields/methods)
-                                            and the candidates are in the drop down menu.
-                                        </Paragraph>
-                                    </ListItem>
+                          </Run>
+                                            </Paragraph>
+                                        </ListItem>
+                                        <ListItem>
+                                            <Paragraph>
+                                                The command input box is actually an editable ComboBox. It provides a string search function.
+                                                It tries to be smart as a user is typing. It helps to search the property (or fields/methods)
+                                                and the candidates are in the drop down menu.
+                                            </Paragraph>
+                                        </ListItem>
 
-                                    <ListItem>
-                                        <Paragraph>
-                                            The internal table initially holds three objects, the RichTextBox, a Selection, and a Document. Only
-                                            the RichTextBox is actually required. The other two are added to the table for purposes of convenience.
-                                            The Selection and Document will not be automatically updated if you use the core parser to load new XAML.
-                                            For this to work, you must do the following:
-                                            <Run FontFamily="Courier New" xml:space="preserve">
+                                        <ListItem>
+                                            <Paragraph>
+                                                The internal table initially holds three objects, the RichTextBox, a Selection, and a Document. Only
+                                                the RichTextBox is actually required. The other two are added to the table for purposes of convenience.
+                                                The Selection and Document will not be automatically updated if you use the core parser to load new XAML.
+                                                For this to work, you must do the following:
+                                                <Run FontFamily="Courier New" xml:space="preserve">
                         
 Document  = RichTextBox.Document;
 Selection = RichTextBox.Selection;
-                    </Run>
-                                        </Paragraph>
-                                    </ListItem>
-                                </List>
+                        </Run>
+                                            </Paragraph>
+                                        </ListItem>
+                                    </List>
 
-                                <Paragraph FontSize="15" FontWeight="Bold">Error messages:</Paragraph>
+                                    <Paragraph FontSize="15" FontWeight="Bold">Error messages:</Paragraph>
 
-                                <Paragraph>There are two primary errors to look for when using the immediate window:</Paragraph>
-                                <List>
-                                    <ListItem>
-                                        <Paragraph>A field, property, or method is not found. This is a parsing error. It will be displayed in the history window. The return value is shown in the history log too. You can examine the return value for possible bugs.</Paragraph>
-                                    </ListItem>
-                                    <ListItem>
-                                        <Paragraph>Exception occurred while invoking a method. This error is shown in the lower TextBox. If an incorrect parameter is passed, the exception will be shown.</Paragraph>
-                                    </ListItem>
-                                </List>
+                                    <Paragraph>There are two primary errors to look for when using the immediate window:</Paragraph>
+                                    <List>
+                                        <ListItem>
+                                            <Paragraph>A field, property, or method is not found. This is a parsing error. It will be displayed in the history window. The return value is shown in the history log too. You can examine the return value for possible bugs.</Paragraph>
+                                        </ListItem>
+                                        <ListItem>
+                                            <Paragraph>Exception occurred while invoking a method. This error is shown in the lower TextBox. If an incorrect parameter is passed, the exception will be shown.</Paragraph>
+                                        </ListItem>
+                                    </List>
 
-                            </Section>
-                        </FlowDocument>
-                    </FlowDocumentScrollViewer>
+                                </Section>
+                            </FlowDocument>
+                        </FlowDocumentScrollViewer>
+                    </Border>
                 </TabItem>
             </TabControl>
         </StackPanel>

--- a/Sample Applications/EditingExaminerDemo/Styles.xaml
+++ b/Sample Applications/EditingExaminerDemo/Styles.xaml
@@ -2,11 +2,6 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:EditingExaminerDemo">
 
-    <Style x:Key="ScrollViewer" TargetType="FlowDocumentScrollViewer">
-        <Setter Property="BorderBrush" Value="Black" />
-        <Setter Property="BorderThickness" Value="1" />
-    </Style>
-
     <Style x:Key="ImmediateWindowLabel" TargetType="Label">
         <Setter Property="BorderBrush" Value="Gray"/>
     </Style>


### PR DESCRIPTION
The bug actually assumes that keyboard focus goes nowhere after the help tab has focus.  But the problem is actually that the focus rectangle is not visible over a border on the FlowDocumentScrollViewer.  This change puts a border around the element to allow some space to show the focus rectangle