### PR TITLE
Fix bug 1145041 by using a color with a higher contrast ratio for error text

### DIFF
--- a/Sample Applications/EditingExaminerDemo/Styles.xaml
+++ b/Sample Applications/EditingExaminerDemo/Styles.xaml
@@ -12,7 +12,7 @@
     </Style>
 
     <Style x:Key="ErrorMessageTextBox" TargetType="TextBox">
-        <Setter Property="Foreground" Value="Red" />
+        <Setter Property="Foreground" Value="DarkRed" />
         <Setter Property="BorderBrush" Value="Red" />
 
         <Style.Triggers>


### PR DESCRIPTION
Red has a contrast-ratio of less than 4.5 - to - 1.  (not compliant with MAS 1.4.3) Changing this to DarkRed which has a contrast-ration of about 10-1