### PR TITLE
Data binding demo accessibility fixes

### DIFF
--- a/Sample Applications/DataBindingDemo/AddProductWindow.cs
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
 
 namespace DataBindingDemo
 {
@@ -28,6 +31,21 @@ namespace DataBindingDemo
             var item = (AuctionItem) (DataContext);
             ((App) Application.Current).AuctionItems.Add(item);
             Close();
+        }
+
+        private void OnValidationError(object sender, ValidationErrorEventArgs e)
+        {
+            // Get the current UIA ItemStatus from the element element. 
+            var oldStatus = AutomationProperties.GetItemStatus((DependencyObject)sender);
+
+            // Set some sample new ItemStatus here... 
+            var newStatus = e.Action == ValidationErrorEventAction.Added ? e.Error.ErrorContent.ToString() : String.Empty;
+            AutomationProperties.SetItemStatus((DependencyObject)sender, newStatus);
+            
+            // Having just set the new ItemStatus, raise a UIA property changed event. Note that the peer may 
+            // be null here unless a UIA client app such as Narrator or the AccEvent SDK tool are running. 
+            var automationPeer = UIElementAutomationPeer.FromElement((UIElement)sender);
+            automationPeer?.RaisePropertyChangedEvent(AutomationElementIdentifiers.ItemStatusProperty, oldStatus, newStatus);
         }
     }
 }

--- a/Sample Applications/DataBindingDemo/AddProductWindow.xaml
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.xaml
@@ -57,9 +57,11 @@
                     <TextBlock Grid.Row="2" Grid.Column="0" Style="{StaticResource SmallTitleStyle}" Margin="0,5,0,5">Start Price:</TextBlock>
 
                     <TextBox Name="StartPriceEntryForm" AutomationProperties.Name="Start Price" Grid.Row="2" Grid.Column="1"
-                             Style="{StaticResource TextStyleTextBox}" Margin="8,5,0,5">
+                             Style="{StaticResource TextStyleTextBox}" Margin="8,5,0,5"
+                             Validation.Error="OnValidationError">
                         <TextBox.Text>
-                            <Binding Path="StartPrice" UpdateSourceTrigger="PropertyChanged">
+                            <Binding Path="StartPrice" UpdateSourceTrigger="PropertyChanged"
+                                     NotifyOnValidationError="True">
                                 <Binding.ValidationRules>
                                     <ExceptionValidationRule />
                                 </Binding.ValidationRules>
@@ -71,9 +73,12 @@
 
                     <TextBox Name="StartDateEntryForm" AutomationProperties.Name="Start Date" Grid.Row="3" Grid.Column="1"
                              Validation.ErrorTemplate="{StaticResource ValidationTemplate}"
-                             Style="{StaticResource TextStyleTextBox}" Margin="8,5,0,5">
+                             Style="{StaticResource TextStyleTextBox}" Margin="8,5,0,5"
+                             Validation.Error="OnValidationError"
+                             AutomationProperties.LiveSetting="Assertive">
                         <TextBox.Text>
                             <Binding Path="StartDate" UpdateSourceTrigger="PropertyChanged"
+                                     NotifyOnValidationError="True"
                                      Converter="{StaticResource DateConverter}">
                                 <Binding.ValidationRules>
                                     <local:FutureDateRule />

--- a/Sample Applications/DataBindingDemo/AuctionItem.cs
+++ b/Sample Applications/DataBindingDemo/AuctionItem.cs
@@ -103,7 +103,7 @@ namespace DataBindingDemo
             {
                 if (value < 0)
                 {
-                    throw new ArgumentException("Price must be positive");
+                    throw new ArgumentException("Price must be positive. Provide a positive price");
                 }
                 _startPrice = value;
                 OnPropertyChanged("StartPrice");

--- a/Sample Applications/DataBindingDemo/FutureDateRule.cs
+++ b/Sample Applications/DataBindingDemo/FutureDateRule.cs
@@ -18,13 +18,14 @@ namespace DataBindingDemo
             }
             catch (FormatException)
             {
-                return new ValidationResult(false, "Value is not a valid date.");
+                return new ValidationResult(false, "Value is not a valid date. Please enter a valid date");
             }
             if (DateTime.Now.Date > date)
             {
-                return new ValidationResult(false, "Please enter a date in the future.");
+                return new ValidationResult(false, "Value is not a future date. Please enter a date in the future.");
             }
             return ValidationResult.ValidResult;
         }
+
     }
 }

--- a/Sample Applications/DataBindingDemo/MainWindow.cs
+++ b/Sample Applications/DataBindingDemo/MainWindow.cs
@@ -1,8 +1,11 @@
 ﻿// // Copyright (c) Microsoft. All rights reserved.
 // // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
 using System.Windows.Data;
 
 namespace DataBindingDemo
@@ -41,11 +44,21 @@ namespace DataBindingDemo
             // This groups the items in the view by the property "Category"
             var groupDescription = new PropertyGroupDescription {PropertyName = "Category"};
             _listingDataView.GroupDescriptions.Add(groupDescription);
+
+            NotifyUpdate();
+
+        }
+
+        private void NotifyUpdate()
+        {
+            var listingPeer = ListBoxAutomationPeer.FromElement(Master);
+            listingPeer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
         }
 
         private void RemoveGrouping(object sender, RoutedEventArgs args)
         {
             _listingDataView.GroupDescriptions.Clear();
+            NotifyUpdate();
         }
 
         private void AddSorting(object sender, RoutedEventArgs args)
@@ -57,21 +70,26 @@ namespace DataBindingDemo
                 new SortDescription("Category", ListSortDirection.Ascending));
             _listingDataView.SortDescriptions.Add(
                 new SortDescription("StartDate", ListSortDirection.Ascending));
+            NotifyUpdate();
         }
 
         private void RemoveSorting(object sender, RoutedEventArgs args)
         {
             _listingDataView.SortDescriptions.Clear();
+            NotifyUpdate();
         }
 
         private void AddFiltering(object sender, RoutedEventArgs args)
         {
             _listingDataView.Filter += ShowOnlyBargainsFilter;
+            NotifyUpdate();
         }
 
         private void RemoveFiltering(object sender, RoutedEventArgs args)
         {
             _listingDataView.Filter -= ShowOnlyBargainsFilter;
+            NotifyUpdate();
         }
     }
+
 }

--- a/Sample Applications/DataBindingDemo/MainWindow.xaml
+++ b/Sample Applications/DataBindingDemo/MainWindow.xaml
@@ -52,8 +52,9 @@
         </CheckBox>
 
 
-        <ListBox Name="Master" AutomationProperties.Name="Master" Grid.Row="2" Grid.ColumnSpan="3" Margin="8"
-                 ItemsSource="{Binding Source={StaticResource ListingDataView}}">
+        <ListBox Name="Master" AutomationProperties.Name="List of Items For Sale" Grid.Row="2" Grid.ColumnSpan="3" Margin="8"
+                 ItemsSource="{Binding Source={StaticResource ListingDataView}}"
+                 AutomationProperties.LiveSetting="Assertive">
             <ListBox.GroupStyle>
                 <GroupStyle
                     HeaderTemplate="{StaticResource GroupingHeaderTemplate}" />
@@ -68,5 +69,6 @@
         <Button Name="OpenAddProduct" Grid.Row="4" Grid.Column="1" Content="Add Product" HorizontalAlignment="Center"
                 Margin="8"
                 Click="OpenAddProductWindow" />
+        
     </Grid>
 </Window>


### PR DESCRIPTION
This fixes a number of Accessibility bugs in the DataBindingDemo sample


**1145075 -- Screenreader does not indicate that the list of items is updated after any checkboxes checked.**
This is fixed by making that listbox  AutomationProperties.LiveSetting="Assertive", and raising a LiveRegionChanged Automation event.

**1145613 -- Screenreader does not read "color information" (this being the validation ui) on an Start price or start date**
This is fixed by notifying on validation errors, setting the AutomationProperties.Status on a validation error.
There was another error where error information was not announced when either of these fields was cleared.

**1159105 -- Screenreader does not announce header for "List of Items for sale"**
This is fixed by correcting the Automation Name
