### PR TITLE
Include color in AuctionItem description

### DIFF
--- a/Sample Applications/DataBindingDemo/AuctionItem.cs
+++ b/Sample Applications/DataBindingDemo/AuctionItem.cs
@@ -78,9 +78,10 @@ namespace DataBindingDemo
             // navigates around inside the item.
 
             return (_specialFeatures == SpecialFeatures.Highlight ?
-                        "SpotLight, " : "") +
+                        "Special Features: Highlight, " : (_specialFeatures == SpecialFeatures.Color ? "Specieal Features: Color": "")) +
                 "Description: " + _description + ", " +
                 "Current price: $" + this.CurrentPrice;
+
         }
         
 


### PR DESCRIPTION
This fixes 1144903 for the DataBindingDemo.  

The purpose of the "star" was already included, but the color was not.  These are the values of the "Special Features" in the Add Products window.