### PR TITLE
Specify AutomationProperties.Name for ListBoxItem

### DIFF
--- a/Sample Applications/CustomComboBox/Styles.xaml
+++ b/Sample Applications/CustomComboBox/Styles.xaml
@@ -189,6 +189,7 @@
         <Setter Property="SnapsToDevicePixels" Value="true" />
         <Setter Property="FocusVisualStyle" Value="{DynamicResource CustomFocusVisual}"/>
         <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="AutomationProperties.Name" Value="{Binding Path=Title}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListBoxItem">


### PR DESCRIPTION
Fix for 1144861:  Screenreader reads as Custom combo box. Movie for all the movie selection and also not reading the name of the movie.

Fix is to bind the AutomationProperties.Name to the Title