### PR TITLE
Fixing bug 1144861 in samples used by accessibility test team.

### DIFF
--- a/Sample Applications/CustomComboBox/Styles.xaml
+++ b/Sample Applications/CustomComboBox/Styles.xaml
@@ -145,6 +145,13 @@
 
     <Style x:Key="listBoxStyle" TargetType="ListBox">
         <Setter Property="Foreground" Value="#AEAEAE"/>
+        <Setter Property="ItemContainerStyle">
+            <Setter.Value>
+                <Style>
+                    <Setter Property="AutomationProperties.Name" Value="{Binding Title}"/>
+                </Style>
+            </Setter.Value>
+        </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListBox">


### PR DESCRIPTION
Fixes Issue #327.

## Description

AutomationProperty.Name was not exposed for each ListBoxItem. Adding AutomationProperty.Name to the ListBoxItem.ItemContainer allowed Narrator to read the Title of each Movie. Narrator required AutomationProperty.Name be added to the ListBox.ItemContainer to read the Movie titles. Otherwise, Narrator reads the class name, which is the same for all Movie items.

## Customer Impact

Screenreader reads as Custom combo box. Movie for all the movie selection and also not reading the name of the movie.

## Regression

No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing

The sample project was tested using Narrator to confirm that the names of the movies are being read correctly.
