### PR TITLE
Fixing bug 1144871 in samples used by accessibility test team.

### DIFF
--- a/Sample Applications/CustomComboBox/MainWindow.xaml
+++ b/Sample Applications/CustomComboBox/MainWindow.xaml
@@ -23,8 +23,8 @@
                              IsTabStop="False"/>
 
         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
-            <TextBlock Text="{Binding SelectedMovie, Converter={StaticResource stringConverter}, ConverterParameter=text}" Style="{DynamicResource streamingTextStyle}"/>
-            <TextBlock Text="{Binding SelectedMovie}" HorizontalAlignment="Center" />
+            <TextBlock Text="{Binding SelectedMovie, Converter={StaticResource stringConverter}, ConverterParameter=text, NotifyOnTargetUpdated=True}" Style="{DynamicResource streamingTextStyle}" TargetUpdated="TextBlock_TargetUpdated" AutomationProperties.LiveSetting="Assertive"/>
+            <TextBlock Text="{Binding SelectedMovie, NotifyOnTargetUpdated=True}" HorizontalAlignment="Center" TargetUpdated="TextBlock_TargetUpdated" AutomationProperties.LiveSetting="Assertive"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/Sample Applications/CustomComboBox/MainWindow.xaml.cs
+++ b/Sample Applications/CustomComboBox/MainWindow.xaml.cs
@@ -32,10 +32,13 @@ namespace CustomComboBox
 
         private void TextBlock_TargetUpdated(object sender, DataTransferEventArgs e)
         {
-            var listingPeer = ListBoxAutomationPeer.FromElement(sender as TextBlock);
-            if(listingPeer != null)
+            if (e.Property == TextBlock.TextProperty)
             {
-                listingPeer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+                var textBlockPeer = UIElementAutomationPeer.FromElement(sender as TextBlock);
+                if(textBlockPeer != null)
+                {
+                    textBlockPeer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+                }
             }
         }
     }

--- a/Sample Applications/CustomComboBox/MainWindow.xaml.cs
+++ b/Sample Applications/CustomComboBox/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;
@@ -27,6 +28,15 @@ namespace CustomComboBox
 
         private void Button_Click(object sender, RoutedEventArgs e)
         {
+        }
+
+        private void TextBlock_TargetUpdated(object sender, DataTransferEventArgs e)
+        {
+            var listingPeer = ListBoxAutomationPeer.FromElement(sender as TextBlock);
+            if(listingPeer != null)
+            {
+                listingPeer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes Issue #328.

## Description

Both TextBlocks in the main window should be read by Narrator when they content changes. Created a handler listening to TargetUpdate events of the TextBlocks and set them as LiveRegion. The new handlers fires an event of LiveRegionChanged for both of the TextBlocks.


## Customer Impact
Screenreader does not tells the user that a movie is streaming.

## Regression
No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing
The sample project was tested using Narrator to confirm that it now speaks when the texts are updated, announcing that a movie is streaming.