### PR TITLE
Fixing bug 1145042 in samples used by accessibility test team.

### DIFF
--- a/Sample Applications/CustomComboBox/MainWindow.xaml
+++ b/Sample Applications/CustomComboBox/MainWindow.xaml
@@ -23,8 +23,8 @@
                              IsTabStop="False"/>
 
         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
-            <TextBlock Text="{Binding SelectedMovie, Converter={StaticResource stringConverter}, ConverterParameter=text}" Style="{DynamicResource streamingTextStyle}"/>
-            <TextBlock Text="{Binding SelectedMovie}" HorizontalAlignment="Center" />
+            <TextBlock Text="{Binding SelectedMovie, Converter={StaticResource stringConverter}, ConverterParameter=text, NotifyOnTargetUpdated=True}" Style="{DynamicResource streamingTextStyle}" TargetUpdated="TextBlock_TargetUpdated" AutomationProperties.LiveSetting="Assertive"/>
+            <TextBlock Text="{Binding SelectedMovie, NotifyOnTargetUpdated=True}" HorizontalAlignment="Center" TargetUpdated="TextBlock_TargetUpdated" AutomationProperties.LiveSetting="Assertive"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/Sample Applications/CustomComboBox/MainWindow.xaml.cs
+++ b/Sample Applications/CustomComboBox/MainWindow.xaml.cs
@@ -32,10 +32,13 @@ namespace CustomComboBox
 
         private void TextBlock_TargetUpdated(object sender, DataTransferEventArgs e)
         {
-            var listingPeer = ListBoxAutomationPeer.FromElement(sender as TextBlock);
-            if(listingPeer != null)
+            if (e.Property == TextBlock.TextProperty)
             {
-                listingPeer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+                var textBlockPeer = UIElementAutomationPeer.FromElement(sender as TextBlock);
+                if(textBlockPeer != null)
+                {
+                    textBlockPeer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+                }
             }
         }
     }

--- a/Sample Applications/CustomComboBox/MainWindow.xaml.cs
+++ b/Sample Applications/CustomComboBox/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;
@@ -27,6 +28,15 @@ namespace CustomComboBox
 
         private void Button_Click(object sender, RoutedEventArgs e)
         {
+        }
+
+        private void TextBlock_TargetUpdated(object sender, DataTransferEventArgs e)
+        {
+            var listingPeer = ListBoxAutomationPeer.FromElement(sender as TextBlock);
+            if(listingPeer != null)
+            {
+                listingPeer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+            }
         }
     }
 }

--- a/Sample Applications/EditingExaminerDemo/MainWindow.xaml
+++ b/Sample Applications/EditingExaminerDemo/MainWindow.xaml
@@ -16,7 +16,7 @@
                 <TabItem Name="RichTab" Header="RichTextBox"
                          AutomationProperties.HelpText="Make edits in this RichTextBox. As you edit, you can see what your edits look like in real time in the tabs below.">
                     <RichTextBox Name="MainEditor" AutomationProperties.Name="Rich Text" TextChanged="UpdateDisplayTabs" AcceptsTab="True" Height="250"
-                                 Width="800" VerticalScrollBarVisibility="Visible" />
+                                 Width="800" VerticalScrollBarVisibility="Visible" BorderBrush="Black" />
                 </TabItem>
                 <TabItem Name="PanelTab" AutomationProperties.Name="Panel" Header="Panel" AutomationProperties.HelpText="Panel Tab">
                     <StackPanel />
@@ -208,7 +208,7 @@ Selection = RichTextBox.Selection;
                     Immediate Window
                 </Label>
                 <TextBox Name="ImmediateWindow" AutomationProperties.Name="Immediate Window" Width="400" Height="205" VerticalScrollBarVisibility="Visible"
-                         IsReadOnly="True"
+                         IsReadOnly="True" BorderBrush="Black"
                          AutomationProperties.HelpText="This provides an instant way to invoke methods, and get or set properties." />
                 <ComboBox Name="CommandInputBox" AutomationProperties.Name="Command input" Width="400" IsEditable="True" LostFocus="CommandInputBox_FocusEvent"
                           GotFocus="CommandInputBox_FocusEvent"


### PR DESCRIPTION
Fixes Issue #327.

## Description
The border color of the Immediate window screen was gray. This color have a contrast ratio less than 3:1 when compared to the border color when focused. The border color was changed to black so the colors have higher contrast ratio.

## Customer Impact
With the lack of contrast, below the 3:1 ratio, the user may not see well when the window is being focused.

## Regression
No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing
The sample project was tested using the Accessibility Insights tool, to assert the contrast ratio of 21:1 between the border color and the background and a ratio of 10:1 between the color of the focused element and the color of the same not focused element.