### PR TITLE
Fixing bug 1144861 in samples used by accessibility test team.

### DIFF
--- a/Sample Applications/CustomComboBox/DropList.cs
+++ b/Sample Applications/CustomComboBox/DropList.cs
@@ -58,6 +58,16 @@ namespace CustomComboBox
             DependencyProperty.Register("ItemsSource", typeof(IEnumerable<object>), typeof(DropList));
 
 
+        public Style ItemContainerStyle
+        {
+            get { return (Style)GetValue(ItemContainerStyleProperty); }
+            set { SetValue(ItemContainerStyleProperty, value); }
+
+        }
+
+        public static readonly DependencyProperty ItemContainerStyleProperty =
+            DependencyProperty.Register("ItemContainerStyle", typeof(Style), typeof(DropList));
+
         public string DisplayMemberPath
         {
             get { return (string)GetValue(DisplayMemberPathProperty); }

--- a/Sample Applications/CustomComboBox/MainWindow.xaml
+++ b/Sample Applications/CustomComboBox/MainWindow.xaml
@@ -19,6 +19,7 @@
                              HorizontalAlignment="Center" VerticalAlignment="Top"
                              Style="{StaticResource DropListStyle}" 
                              ItemsSource="{Binding Movies}" Command="{Binding OnWatchNow}" 
+                             ItemContainerStyle="{StaticResource MovieItemContainerStyle}"
                              DisplayMemberPath="Title"
                              IsTabStop="False"/>
 

--- a/Sample Applications/CustomComboBox/Styles.xaml
+++ b/Sample Applications/CustomComboBox/Styles.xaml
@@ -143,15 +143,12 @@
         </ObjectAnimationUsingKeyFrames>
     </Storyboard>
 
+    <Style x:Key="MovieItemContainerStyle">
+        <Setter Property="AutomationProperties.Name" Value="{Binding Title}"/>
+    </Style>
+
     <Style x:Key="listBoxStyle" TargetType="ListBox">
         <Setter Property="Foreground" Value="#AEAEAE"/>
-        <Setter Property="ItemContainerStyle">
-            <Setter.Value>
-                <Style>
-                    <Setter Property="AutomationProperties.Name" Value="{Binding Title}"/>
-                </Style>
-            </Setter.Value>
-        </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListBox">
@@ -337,6 +334,7 @@
                         <ListBox Name="lstBx" AutomationProperties.Name="Movies" BorderThickness="1" Height="0" Grid.Row="1" Style="{StaticResource listBoxStyle}"
                                      FocusVisualStyle="{DynamicResource CustomFocusVisual}"
                                      ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ItemsSource}"
+                                     ItemContainerStyle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ItemContainerStyle}"
                                      DisplayMemberPath="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMemberPath}" 
                                      SelectedValuePath="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMemberPath}"
                                      TabIndex="1">

--- a/Sample Applications/CustomComboBox/Styles.xaml
+++ b/Sample Applications/CustomComboBox/Styles.xaml
@@ -145,6 +145,13 @@
 
     <Style x:Key="listBoxStyle" TargetType="ListBox">
         <Setter Property="Foreground" Value="#AEAEAE"/>
+        <Setter Property="ItemContainerStyle">
+            <Setter.Value>
+                <Style>
+                    <Setter Property="AutomationProperties.Name" Value="{Binding Title}"/>
+                </Style>
+            </Setter.Value>
+        </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListBox">


### PR DESCRIPTION
Fixes Issue #327.

## Description

AutomationProperty.Name was not exposed for each ListBoxItem. Adding AutomationProperty.Name to the ListBoxItem.ItemContainer allowed Narrator to read the Title of each Movie. Narrator required AutomationProperty.Name be added to the ListBox.ItemContainer to read the Movie titles. Otherwise, Narrator reads the class name, which is the same for all Movie items.

## Customer Impact

Screenreader reads as Custom combo box. Movie for all the movie selection and also not reading the name of the movie.

## Regression

No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing

The sample project was tested using Narrator to confirm that the names of the movies are being read correctly.
