### PR TITLE
Fixing bug 1260549 in samples used by accessibility team.

### DIFF
--- a/Sample Applications/DataBindingDemo/AddProductWindow.cs
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
+using System.Windows.Data;
 
 namespace DataBindingDemo
 {
@@ -31,6 +32,15 @@ namespace DataBindingDemo
             var item = (AuctionItem) (DataContext);
             ((App) Application.Current).AuctionItems.Add(item);
             Close();
+        }
+
+        private void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var peer = UIElementAutomationPeer.FromElement(sender as ComboBox);
+            if(peer != null)
+            {
+                peer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+            }
         }
 
         private void OnValidationError(object sender, ValidationErrorEventArgs e)

--- a/Sample Applications/DataBindingDemo/AddProductWindow.xaml
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.xaml
@@ -106,6 +106,8 @@
                     <ComboBox Name="SpecialFeaturesEntryForm" AutomationProperties.Name="Special Features" Grid.Row="5" Grid.Column="1"
                               SelectedValue="{Binding Path=SpecialFeatures}"
                               Style="{StaticResource ComboBoxStyle}"
+                              SelectionChanged="OnSelectionChanged"
+                              AutomationProperties.LiveSetting="Assertive"
                               ItemContainerStyle="{StaticResource ComboBoxItemStyle}" Margin="8,5,0,5">
                         <local:SpecialFeatures>None</local:SpecialFeatures>
                         <local:SpecialFeatures>Color</local:SpecialFeatures>

--- a/Sample Applications/DataBindingDemo/AddProductWindow.xaml
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.xaml
@@ -91,6 +91,8 @@
                     <ComboBox Name="CategoryEntryForm" AutomationProperties.Name="Category" Grid.Row="4" Grid.Column="1"
                               SelectedValue="{Binding Path=Category}"
                               Style="{StaticResource ComboBoxStyle}"
+                              SelectionChanged="OnSelectionChanged"
+                              AutomationProperties.LiveSetting="Assertive"
                               ItemContainerStyle="{StaticResource ComboBoxItemStyle}" Margin="8,5,0,5">
                         <local:ProductCategory>Books</local:ProductCategory>
                         <local:ProductCategory>Computers</local:ProductCategory>


### PR DESCRIPTION
Fixes Issue #336.

## Description

When the ComboBox is collapsed, and the user changes its value using the Up/Down arrow keys, the Narrator does not speak. The SelectionChanged event of ComboBox was used with a handler thar raises LiveRegionChanged event, so the Narrator will say the name of the selected option.

## Customer Impact

The user using keyboard to navigate could not know what is selected in the ComboBox.

## Regression

No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing

The sample project was tested using keyboard to assert the narrator says the selected item even when the ComboBox is collapsed.
