### PR TITLE
Fixing bug 1144878 in samples used by accessibility team.

### DIFF
--- a/Sample Applications/CustomComboBox/ExpandableToggleButton.cs
+++ b/Sample Applications/CustomComboBox/ExpandableToggleButton.cs
@@ -84,12 +84,9 @@ namespace CustomComboBox
     
     public class ExpandableToggleButtonAutomationPeer : ButtonAutomationPeer, IExpandCollapseProvider
     {
-        private ExpandableToggleButton button;
+        private ExpandableToggleButton Button { get { return Owner as ExpandableToggleButton; } }
 
-        public ExpandableToggleButtonAutomationPeer(ExpandableToggleButton owner) : base(owner)
-        {
-            this.button = owner;
-        }
+        public ExpandableToggleButtonAutomationPeer(ExpandableToggleButton owner) : base(owner) {}
 
         public override object GetPattern(PatternInterface patternInterface)
         {
@@ -104,18 +101,18 @@ namespace CustomComboBox
         {
             get
             {
-                return this.button.State;
+                return Button.State;
             }
         }
 
         public void Expand()
         {
-            this.button.State = ExpandCollapseState.Expanded;
+            Button.State = ExpandCollapseState.Expanded;
         }
 
         public void Collapse()
         {
-            this.button.State = ExpandCollapseState.Collapsed;
+            Button.State = ExpandCollapseState.Collapsed;
         }
     }
 }

--- a/Sample Applications/CustomComboBox/ExpandableToggleButton.cs
+++ b/Sample Applications/CustomComboBox/ExpandableToggleButton.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+
+namespace CustomComboBox
+{
+    public class ExpandableToggleButton : Button
+    {
+        private ExpandableToggleButtonAutomationPeer peer;
+
+        private ExpandCollapseState state = ExpandCollapseState.Collapsed;
+
+        public static readonly RoutedEvent ExpandedEvent = EventManager.RegisterRoutedEvent("Expanded", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(ExpandableToggleButton));
+
+        public static readonly RoutedEvent CollapsedEvent = EventManager.RegisterRoutedEvent("Collapsed", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(ExpandableToggleButton));
+
+        public event RoutedEventHandler Expanded
+        {
+            add { AddHandler(ExpandedEvent, value); }
+            remove { RemoveHandler(ExpandedEvent, value); }
+        }
+
+        public event RoutedEventHandler Collapsed
+        {
+            add { AddHandler(CollapsedEvent, value); }
+            remove { RemoveHandler(CollapsedEvent, value); }
+        }
+
+        public ExpandCollapseState State
+        {
+            get
+            {
+                return this.state;
+            }
+            set
+            {
+                ExpandCollapseState previousState = this.state;
+
+                this.state = value;
+
+                if ((this.peer != null) && this.state != previousState)
+                {
+                    this.peer.RaisePropertyChangedEvent(
+                       ExpandCollapsePatternIdentifiers.ExpandCollapseStateProperty,
+                       previousState,
+                       this.state);
+                    if(this.state == ExpandCollapseState.Collapsed)
+                    {
+                        RoutedEventArgs collapsedEventArgs = new RoutedEventArgs(CollapsedEvent);
+                        RaiseEvent(collapsedEventArgs);
+                    } else
+                    {
+                        RoutedEventArgs expandedEventArgs = new RoutedEventArgs(ExpandedEvent);
+                        RaiseEvent(expandedEventArgs);
+                    }
+                }
+            }
+        }
+
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            if(this.peer == null)
+            {
+                this.peer = new ExpandableToggleButtonAutomationPeer(this);
+            }
+
+            return this.peer;
+        }
+
+        protected override void OnClick()
+        {
+            this.State = (this.State == ExpandCollapseState.Collapsed ? ExpandCollapseState.Expanded :
+                ExpandCollapseState.Collapsed);
+
+            // base.OnClick();
+        }
+    }
+    
+    public class ExpandableToggleButtonAutomationPeer : ButtonAutomationPeer, IExpandCollapseProvider
+    {
+        private ExpandableToggleButton button;
+
+        public ExpandableToggleButtonAutomationPeer(ExpandableToggleButton owner) : base(owner)
+        {
+            this.button = owner;
+        }
+
+        public override object GetPattern(PatternInterface patternInterface)
+        {
+            if(patternInterface == PatternInterface.ExpandCollapse)
+            {
+                return this;
+            }
+            return base.GetPattern(patternInterface);
+        }
+
+        public ExpandCollapseState ExpandCollapseState
+        {
+            get
+            {
+                return this.button.State;
+            }
+        }
+
+        public void Expand()
+        {
+            this.button.State = ExpandCollapseState.Expanded;
+        }
+
+        public void Collapse()
+        {
+            this.button.State = ExpandCollapseState.Collapsed;
+        }
+    }
+}

--- a/Sample Applications/CustomComboBox/Styles.xaml
+++ b/Sample Applications/CustomComboBox/Styles.xaml
@@ -246,10 +246,10 @@
                                     <ColumnDefinition  x:Name="col1" Width="1"/>
                                     <ColumnDefinition/>
                                 </Grid.ColumnDefinitions>
-                                <ToggleButton FocusVisualStyle="{DynamicResource CustomFocusVisual}"
-                                              AutomationProperties.Name="Play" TabIndex="0">
-                                    <ToggleButton.Template>
-                                        <ControlTemplate TargetType="ToggleButton">
+                                <local:ExpandableToggleButton FocusVisualStyle="{DynamicResource CustomFocusVisual}"
+                                              AutomationProperties.Name="Movies list" TabIndex="0">
+                                    <local:ExpandableToggleButton.Template>
+                                        <ControlTemplate TargetType="local:ExpandableToggleButton">
                                             <Border Background="Transparent">
                                                 <Polygon x:Name="polygon" Points="12,12 12,26, 22,19" Fill="#6BE1FF" RenderTransformOrigin="0.5,0.5"
                                                              HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
@@ -262,14 +262,14 @@
                                                 </Polygon>
                                             </Border>
                                             <ControlTemplate.Triggers>
-                                                <EventTrigger RoutedEvent="ToggleButton.Checked">
+                                                <EventTrigger RoutedEvent="local:ExpandableToggleButton.Expanded">
                                                     <BeginStoryboard>
                                                         <Storyboard>
                                                             <DoubleAnimation Storyboard.TargetName="polyRotate" Storyboard.TargetProperty="Angle" From="0" To="90" Duration="0:0:0.5"/>
                                                         </Storyboard>
                                                     </BeginStoryboard>
                                                 </EventTrigger>
-                                                <EventTrigger RoutedEvent="ToggleButton.Unchecked">
+                                                <EventTrigger RoutedEvent="local:ExpandableToggleButton.Collapsed">
                                                     <BeginStoryboard>
                                                         <Storyboard>
                                                             <DoubleAnimation Storyboard.TargetName="polyRotate" Storyboard.TargetProperty="Angle" From="90" To="0" Duration="0:0:0.5"/>
@@ -281,8 +281,8 @@
                                                 </DataTrigger>
                                             </ControlTemplate.Triggers>
                                         </ControlTemplate>
-                                    </ToggleButton.Template>
-                                </ToggleButton>
+                                    </local:ExpandableToggleButton.Template>
+                                </local:ExpandableToggleButton>
                                 <Rectangle x:Name="line" Grid.Column="1">
                                     <Rectangle.Fill>
                                         <LinearGradientBrush StartPoint="0.25,0" EndPoint="1,1">
@@ -340,14 +340,14 @@
                         </ListBox>
 
                         <Grid.Triggers>
-                            <EventTrigger RoutedEvent="ToggleButton.Checked">
+                            <EventTrigger RoutedEvent="local:ExpandableToggleButton.Expanded">
                                 <BeginStoryboard>
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetName="lstBx" Storyboard.TargetProperty="Height" From="0" To="60" Duration="0:0:0.5"/>
                                     </Storyboard>
                                 </BeginStoryboard>
                             </EventTrigger>
-                            <EventTrigger RoutedEvent="ToggleButton.Unchecked">
+                            <EventTrigger RoutedEvent="local:ExpandableToggleButton.Collapsed">
                                 <BeginStoryboard>
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetName="lstBx" Storyboard.TargetProperty="Height" From="60" To="0" Duration="0:0:0.5"/>


### PR DESCRIPTION
Fixes Issue #338.

## Description

The AutomationProperties.Name of the button was "Play" and was changed to "Movies list". Also, the button was narrated as "On" and "Off" by the narrator, instead of the desirable "Collapsed" and "Expanded". It was solved by changed the ToggleButton to a custom ExpandableToggleButton class. The automation peer of this one implements "IExpanderProvider", making the narrator speaks correctly.

## Customer Impact

The user could be confused by the name of the button and the state said by the narrator.

## Regression

No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing

The sample project was tested using narrator to assert it says the correct name and the correct states.
