### PR TITLE
Fixing bug 1144903 in sample used by accessibility test team.

### DIFF
--- a/Sample Applications/DataBindingDemo/AuctionItem.cs
+++ b/Sample Applications/DataBindingDemo/AuctionItem.cs
@@ -45,45 +45,6 @@ namespace DataBindingDemo
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }
 
-        public override string ToString()
-        {
-            // All important information conveyed visually in the AuctionItem must
-            // be conveyed programmatically. The use of border color is purely 
-            // decorative, and so does not need to be exposed programmatically. The
-            // use of the star however in the visuals is important, as is all the 
-            // text shown in the item. These data can be exposed programmatically 
-            // through the UI Automation (UIA) Name property of the item by returning 
-            // the desired string in ToString() here. That string will typically be
-            // announced by a screen reader when arrowing to the item. The string is  
-            // not overwhelming when announced, but the order in which the data is 
-            // exposed in the string should match the order in which customers will 
-            // want to access it. So when the customer arrows quickly through the 
-            // list to reach an item of interest, the announcement should be ordered 
-            // to enable that rapid navigation through the items.
-
-            // Important: A shipping app would use localized text and currency
-            // symbols here. It also would consider whether the simple concatenation
-            // of the text would provide the expected experience in all regions.
-            // In some regions the text might need to be returned in some other order.
-
-            // Important: The text contained inside the item is exposed through the
-            // Control view of the UI Automation (UIA) API. This indicates to a 
-            // screen reader that the UI is of interest to customers. However, by 
-            // default the star UI is not exposed in this way. Given that the 
-            // information conveyed through the use of the star is very important, 
-            // it must be exposed programmatically to customers. That is being 
-            // achieved here by including related information in the accessible name 
-            // of the item. If that information was not being included here, action  
-            // must be taken to enable the star to be reached when a screen reader 
-            // navigates around inside the item.
-
-            return (_specialFeatures == SpecialFeatures.Highlight ?
-                        "SpotLight, " : "") +
-                "Description: " + _description + ", " +
-                "Current price: $" + this.CurrentPrice;
-        }
-        
-
         #region Properties Getters and Setters
 
         public string Description

--- a/Sample Applications/DataBindingDemo/MainWindow.xaml
+++ b/Sample Applications/DataBindingDemo/MainWindow.xaml
@@ -54,6 +54,7 @@
 
         <ListBox Name="Master" AutomationProperties.Name="List of Items For Sale" Grid.Row="2" Grid.ColumnSpan="3" Margin="8"
                  ItemsSource="{Binding Source={StaticResource ListingDataView}}"
+                 ItemContainerStyle="{StaticResource AuctionItemStyle}"
                  AutomationProperties.LiveSetting="Assertive">
             <ListBox.GroupStyle>
                 <GroupStyle

--- a/Sample Applications/DataBindingDemo/MainWindow.xaml
+++ b/Sample Applications/DataBindingDemo/MainWindow.xaml
@@ -54,7 +54,7 @@
 
         <ListBox Name="Master" AutomationProperties.Name="List of Items For Sale" Grid.Row="2" Grid.ColumnSpan="3" Margin="8"
                  ItemsSource="{Binding Source={StaticResource ListingDataView}}"
-                 ItemContainerStyle="{StaticResource AuctionItemStyle}"
+                 ItemContainerStyle="{StaticResource AuctionItemContainerStyle}"
                  AutomationProperties.LiveSetting="Assertive">
             <ListBox.GroupStyle>
                 <GroupStyle

--- a/Sample Applications/DataBindingDemo/Styles.xaml
+++ b/Sample Applications/DataBindingDemo/Styles.xaml
@@ -116,7 +116,7 @@
         <Setter Property="Width" Value="500" />
     </Style>
 
-    <Style x:Key="AuctionItemStyle">
+    <Style x:Key="AuctionItemContainerStyle">
         <Setter Property="AutomationProperties.Name">
             <Setter.Value>
                 <MultiBinding StringFormat="{} Color: {0}, Description: {1}, Current price: ${2}">

--- a/Sample Applications/DataBindingDemo/Styles.xaml
+++ b/Sample Applications/DataBindingDemo/Styles.xaml
@@ -116,6 +116,18 @@
         <Setter Property="Width" Value="500" />
     </Style>
 
+    <Style x:Key="AuctionItemStyle">
+        <Setter Property="AutomationProperties.Name">
+            <Setter.Value>
+                <MultiBinding StringFormat="{} Color: {0}, Description: {1}, Current price: ${2}">
+                    <Binding Path="SpecialFeatures" />
+                    <Binding Path="Description" />
+                    <Binding Path="CurrentPrice" />
+                </MultiBinding>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="BorderStyle" TargetType="Border">
         <Setter Property="BorderThickness" Value="0,0,0,2" />
         <Setter Property="BorderBrush" Value="Black" />


### PR DESCRIPTION
Fixes Issue #342.

## Description

The narrator was not recieving the color information from AuctionItem. The code was changed to instead of sending this information by a toString method, getting this from a Binding. Also, added the color information to the resulting string.

## Customer Impact

Screenreader user could not get the information of the color.

## Regression

No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing

The sample project was tested using Narrator to assert all the informations are been read and are correct.
