### PR TITLE
Fixing bug 1144793 in samples used by accessibility test team.

### DIFF
--- a/Sample Applications/EditingExaminerDemo/MainWindow.xaml
+++ b/Sample Applications/EditingExaminerDemo/MainWindow.xaml
@@ -16,7 +16,7 @@
                 <TabItem Name="RichTab" Header="RichTextBox"
                          AutomationProperties.HelpText="Make edits in this RichTextBox. As you edit, you can see what your edits look like in real time in the tabs below.">
                     <RichTextBox Name="MainEditor" AutomationProperties.Name="Rich Text" TextChanged="UpdateDisplayTabs" AcceptsTab="True" Height="250"
-                                 Width="800" VerticalScrollBarVisibility="Visible" />
+                                 Width="800" VerticalScrollBarVisibility="Visible" BorderBrush="Black" />
                 </TabItem>
                 <TabItem Name="PanelTab" AutomationProperties.Name="Panel" Header="Panel" AutomationProperties.HelpText="Panel Tab">
                     <StackPanel />
@@ -208,7 +208,7 @@ Selection = RichTextBox.Selection;
                     Immediate Window
                 </Label>
                 <TextBox Name="ImmediateWindow" AutomationProperties.Name="Immediate Window" Width="400" Height="205" VerticalScrollBarVisibility="Visible"
-                         IsReadOnly="True"
+                         IsReadOnly="True" BorderBrush="Black"
                          AutomationProperties.HelpText="This provides an instant way to invoke methods, and get or set properties." />
                 <ComboBox Name="CommandInputBox" AutomationProperties.Name="Command input" Width="400" IsEditable="True" LostFocus="CommandInputBox_FocusEvent"
                           GotFocus="CommandInputBox_FocusEvent"

--- a/Sample Applications/EditingExaminerDemo/MainWindow.xaml
+++ b/Sample Applications/EditingExaminerDemo/MainWindow.xaml
@@ -209,6 +209,7 @@ Selection = RichTextBox.Selection;
                 </Label>
                 <TextBox Name="ImmediateWindow" AutomationProperties.Name="Immediate Window" Width="400" Height="205" VerticalScrollBarVisibility="Visible"
                          IsReadOnly="True" BorderBrush="Black"
+                         IsReadOnlyCaretVisible="True"
                          AutomationProperties.HelpText="This provides an instant way to invoke methods, and get or set properties." />
                 <ComboBox Name="CommandInputBox" AutomationProperties.Name="Command input" Width="400" IsEditable="True" LostFocus="CommandInputBox_FocusEvent"
                           GotFocus="CommandInputBox_FocusEvent"


### PR DESCRIPTION
Fixes Issue #343.

## Description

The IsReadyOnlyCaretVisible property of immediate window was set to true. Then, a keyboard user can scroll trhought the text.

## Customer Impact

A keyboard only user could not scroll trought the text inside immediate window using only the keyboard.

## Regression

No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing

The sample project was tested using keyboard to assert we can focus and scroll the text using keyboard.
