### PR TITLE
Fixing bug 1260556 in samples used by accessibility test team.

### DIFF
--- a/Sample Applications/DataBindingDemo/MainWindow.xaml
+++ b/Sample Applications/DataBindingDemo/MainWindow.xaml
@@ -52,7 +52,7 @@
         </CheckBox>
 
 
-        <ListBox Name="Master" AutomationProperties.Name="List of Items For Sale" Grid.Row="2" Grid.ColumnSpan="3" Margin="8"
+        <ListBox Name="Master" AutomationProperties.Name="Items For Sale" Grid.Row="2" Grid.ColumnSpan="3" Margin="8"
                  ItemsSource="{Binding Source={StaticResource ListingDataView}}"
                  AutomationProperties.LiveSetting="Assertive">
             <ListBox.GroupStyle>


### PR DESCRIPTION
Fixes Issue #347.

## Description

The Automation.Name property of the list of items included the word "List".

## Customer Impact

When used narrator, the word "List" would be said when reading the type of the control and the name of the list.

## Regression

No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing

The sample project was teted using "Accessibility Insights" to assure the error no longer exists.
