### PR TITLE
Fixing bug 1145616 and 1145613 in samples used by accessibility test team.

### DIFF
--- a/Sample Applications/DataBindingDemo/AddProductWindow.cs
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.cs
@@ -26,11 +26,34 @@ namespace DataBindingDemo
                 SpecialFeatures.None);
         }
 
+        private void AnnounceError(string message)
+        {
+            ErrorTextBlock.Visibility = Visibility.Visible;
+            ErrorTextBlock.Text = message;
+            var automationPeer = UIElementAutomationPeer.CreatePeerForElement(ErrorTextBlock);
+            automationPeer?.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+        }
+
         private void SubmitProduct(object sender, RoutedEventArgs e)
         {
-            var item = (AuctionItem) (DataContext);
-            ((App) Application.Current).AuctionItems.Add(item);
-            Close();
+            var automationPeer = UIElementAutomationPeer.CreatePeerForElement(ErrorTextBlock);
+
+            if(StartDateEntryForm.Text.Length == 0 || StartPriceEntryForm.Text.Length == 0)
+            {
+                AnnounceError("Please, fill both date and start price");
+            } else if (Validation.GetHasError(StartDateEntryForm))
+            {
+                AnnounceError("Please, enter a valid date");
+            } else if (Validation.GetHasError(StartPriceEntryForm))
+            {
+                AnnounceError("Please, enter a valid price");
+            } else
+            {
+                var item = (AuctionItem)(DataContext);
+                ((App) Application.Current).AuctionItems.Add(item);
+                Close();
+            }
+
         }
 
         private void OnValidationError(object sender, ValidationErrorEventArgs e)

--- a/Sample Applications/DataBindingDemo/AddProductWindow.xaml
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.xaml
@@ -34,6 +34,7 @@
                         <RowDefinition />
                         <RowDefinition />
                         <RowDefinition />
+                        <RowDefinition />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="106" />
@@ -54,9 +55,9 @@
                              Text="{Binding Path=Description, UpdateSourceTrigger=PropertyChanged}"
                              Style="{StaticResource TextStyleTextBox}" Margin="8,5,0,5" />
 
-                    <TextBlock Grid.Row="2" Grid.Column="0" Style="{StaticResource SmallTitleStyle}" Margin="0,5,0,5">Start Price:</TextBlock>
+                    <TextBlock Grid.Row="2" Grid.Column="0" Style="{StaticResource SmallTitleStyle}" Margin="0,5,0,5">Start Price: *</TextBlock>
 
-                    <TextBox Name="StartPriceEntryForm" AutomationProperties.Name="Start Price" Grid.Row="2" Grid.Column="1"
+                    <TextBox Name="StartPriceEntryForm" AutomationProperties.Name="Start Price, Required" Grid.Row="2" Grid.Column="1"
                              Style="{StaticResource TextStyleTextBox}" Margin="8,5,0,5"
                              Validation.Error="OnValidationError">
                         <TextBox.Text>
@@ -69,9 +70,9 @@
                         </TextBox.Text>
                     </TextBox>
 
-                    <TextBlock Grid.Row="3" Grid.Column="0" Style="{StaticResource SmallTitleStyle}" Margin="0,5,0,5">Start Date:</TextBlock>
+                    <TextBlock Grid.Row="3" Grid.Column="0" Style="{StaticResource SmallTitleStyle}" Margin="0,5,0,5">Start Date: *</TextBlock>
 
-                    <TextBox Name="StartDateEntryForm" AutomationProperties.Name="Start Date" Grid.Row="3" Grid.Column="1"
+                    <TextBox Name="StartDateEntryForm" AutomationProperties.Name="Start Date, Required" Grid.Row="3" Grid.Column="1"
                              Validation.ErrorTemplate="{StaticResource ValidationTemplate}"
                              Style="{StaticResource TextStyleTextBox}" Margin="8,5,0,5"
                              Validation.Error="OnValidationError"
@@ -120,6 +121,9 @@
 
                     <Button Name="Submit" Grid.Row="6" Grid.Column="1" HorizontalAlignment="Right" Content="Submit"
                             Margin="5" Click="SubmitProduct" />
+                    <TextBlock Name="ErrorTextBlock" Grid.Row="7" Grid.Column="1" HorizontalAlignment="Right" Visibility="Collapsed"
+                               AutomationProperties.LiveSetting="Assertive"
+                               Style="{StaticResource ErrorTextBlockStyle}" />
                 </Grid>
             </Border>
             <ContentControl Name="ShortPreview" Grid.Row="1"

--- a/Sample Applications/DataBindingDemo/Styles.xaml
+++ b/Sample Applications/DataBindingDemo/Styles.xaml
@@ -146,4 +146,8 @@
         </Style.Triggers>
     </Style>
 
+    <Style x:Key="ErrorTextBlockStyle" TargetType="TextBlock">
+        <Setter Property="Foreground" Value="Red" />
+    </Style>
+
 </ResourceDictionary>


### PR DESCRIPTION
Fixes issues #349 and #350.

## Description

The AddProduct window of DataBindingDemo sample has two fields that should be required, Date and Start price, but it was not marked as required. I added a * character to indicate this in the text, and included this information on the AutomationProperties.Name property of both Controls.
Also, I added a TextBlock to show an error whenever a user press the AddProduct button with invalid Date or StartPrice values. If one of them is empty, this text tells the user to fill in both, and if there is an error with the input, it also tells the user. This label is a LivingRegion so it also seen by the narrator.

## Customer Impact

When using the sample app, the user would not know both Date and StartPrice are required, and when the AddProduct button was pressed with invalid inputs for those field, it would not show an error message.

## Regression

No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing

The sample project was tested using narrator to assert the informations are being said.
