### PR TITLE
Updating fix to bug 1159083 in samples used by accessibility test team. 

### DIFF
--- a/Sample Applications/CustomComboBox/Styles.xaml
+++ b/Sample Applications/CustomComboBox/Styles.xaml
@@ -143,8 +143,9 @@
         </ObjectAnimationUsingKeyFrames>
     </Storyboard>
 
-    <Style x:Key="MovieItemContainerStyle">
+    <Style x:Key="MovieItemContainerStyle" TargetType="Control">
         <Setter Property="AutomationProperties.Name" Value="{Binding Title}"/>
+        <Setter Property="Focusable" Value="{Binding Focusable, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBox}, AncestorLevel=1}}" />
     </Style>
 
     <Style x:Key="listBoxStyle" TargetType="ListBox">
@@ -193,7 +194,6 @@
         <Setter Property="SnapsToDevicePixels" Value="true" />
         <Setter Property="FocusVisualStyle" Value="{DynamicResource CustomFocusVisual}"/>
         <Setter Property="OverridesDefaultStyle" Value="true" />
-        <Setter Property="Focusable" Value="{Binding Path=Focusable, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBox}, AncestorLevel=1}}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListBoxItem">
@@ -352,7 +352,7 @@
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetName="lstBx" Storyboard.TargetProperty="Height" From="0" To="60" Duration="0:0:0.5"/>
                                         <BooleanAnimationUsingKeyFrames Storyboard.TargetName="lstBx" Storyboard.TargetProperty="Focusable">
-                                            <DiscreteBooleanKeyFrame KeyTime="00:00:01" Value="True"/>
+                                            <DiscreteBooleanKeyFrame KeyTime="00:00:00" Value="True"/>
                                         </BooleanAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </BeginStoryboard>
@@ -362,7 +362,7 @@
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetName="lstBx" Storyboard.TargetProperty="Height" From="60" To="0" Duration="0:0:0.5"/>
                                         <BooleanAnimationUsingKeyFrames Storyboard.TargetName="lstBx" Storyboard.TargetProperty="Focusable">
-                                            <DiscreteBooleanKeyFrame KeyTime="00:00:01" Value="False"/>
+                                            <DiscreteBooleanKeyFrame KeyTime="00:00:00" Value="False"/>
                                         </BooleanAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </BeginStoryboard>


### PR DESCRIPTION
Fixes Issue #334.

## Description

The toggle button changes the height of the movies list from zero to the completed size, but the movies are still focusable when the list is collapsed. The toggle button event was used to change the property Focusable of the list and all the children of the list now inherit this property from it.

The previous fix needed to be updated to adapt to the chenges in the code from other bugfixes.

## Customer Impact

The user using keyboard to navigate could get confused by focusing elements that are collapsed.

## Regression

No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing

The sample project was tested using keyboard to assert we cant focus an element of the collapsed list.
