### PR TITLE
Updating fix bug 1145042 in samples used by accessibility team

### DIFF
--- a/Sample Applications/EditingExaminerDemo/MainWindow.xaml
+++ b/Sample Applications/EditingExaminerDemo/MainWindow.xaml
@@ -16,6 +16,7 @@
                 <TabItem Name="RichTab" Header="RichTextBox"
                          AutomationProperties.HelpText="Make edits in this RichTextBox. As you edit, you can see what your edits look like in real time in the tabs below.">
                     <RichTextBox Name="MainEditor" AutomationProperties.Name="Rich Text" TextChanged="UpdateDisplayTabs" AcceptsTab="True" Height="250"
+                                 Style="{StaticResource TextBoxBorderContrastStyle}"
                                  Width="800" VerticalScrollBarVisibility="Visible" BorderBrush="Black" />
                 </TabItem>
                 <TabItem Name="PanelTab" AutomationProperties.Name="Panel" Header="Panel" AutomationProperties.HelpText="Panel Tab">
@@ -209,6 +210,7 @@ Selection = RichTextBox.Selection;
                 </Label>
                 <TextBox Name="ImmediateWindow" AutomationProperties.Name="Immediate Window" Width="400" Height="205" VerticalScrollBarVisibility="Visible"
                          IsReadOnly="True" BorderBrush="Black"
+                         Style="{StaticResource TextBoxBorderContrastStyle}"
                          IsReadOnlyCaretVisible="True"
                          AutomationProperties.HelpText="This provides an instant way to invoke methods, and get or set properties." />
                 <ComboBox Name="CommandInputBox" AutomationProperties.Name="Command input" Width="400" IsEditable="True" LostFocus="CommandInputBox_FocusEvent"

--- a/Sample Applications/EditingExaminerDemo/Styles.xaml
+++ b/Sample Applications/EditingExaminerDemo/Styles.xaml
@@ -28,4 +28,34 @@
             </DataTrigger>
         </Style.Triggers>
     </Style>
+
+    <Style x:Key="TextBoxBorderContrastStyle" TargetType="Control">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type TextBoxBase}">
+                    <Border x:Name="border"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="True">
+                        <ScrollViewer x:Name="PART_ContentHost" 
+                            Focusable="false" 
+                            HorizontalScrollBarVisibility="Hidden" 
+                            VerticalScrollBarVisibility="Hidden" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter TargetName="border" Property="Opacity" Value="0.56"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter TargetName="border" Property="BorderBrush" Value="Blue" />
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="true">
+                            <Setter TargetName="border" Property="BorderBrush" Value="Blue" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>


### PR DESCRIPTION
Fixes Issue #330.

## Description
The border color of the Immediate window screen was gray. This color have a contrast ratio less than 3:1 when compared to the border color when focused. The border color was changed to black so the colors have higher contrast ratio.

**Also, the border color when focused and hovered was changed to a darker blue, so the contrast with the white background is higher than 3:1 ratio.**

## Customer Impact
With the lack of contrast, below the 3:1 ratio, the user may not see well when the window is being focused.

## Regression
No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing
The sample project was tested using the Accessibility Insights tool, to assert the contrast ratio of 21:1 between the border color and the background and a ratio of 10:1 between the color of the focused element and the color of the same not focused element.