### PR TITLE
Updating fix to bug 1145616 in samples used by accessibility test team

### DIFF
--- a/Sample Applications/DataBindingDemo/AddProductWindow.xaml
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.xaml
@@ -57,8 +57,9 @@
 
                     <TextBlock Grid.Row="2" Grid.Column="0" Style="{StaticResource SmallTitleStyle}" Margin="0,5,0,5">Start Price: *</TextBlock>
 
-                    <TextBox Name="StartPriceEntryForm" AutomationProperties.Name="Start Price, Required" Grid.Row="2" Grid.Column="1"
+                    <TextBox Name="StartPriceEntryForm" AutomationProperties.Name="Start Price" Grid.Row="2" Grid.Column="1"
                              Style="{StaticResource TextStyleTextBox}" Margin="8,5,0,5"
+                             AutomationProperties.IsRequiredForForm="True"
                              Validation.Error="OnValidationError">
                         <TextBox.Text>
                             <Binding Path="StartPrice" UpdateSourceTrigger="PropertyChanged"
@@ -72,10 +73,11 @@
 
                     <TextBlock Grid.Row="3" Grid.Column="0" Style="{StaticResource SmallTitleStyle}" Margin="0,5,0,5">Start Date: *</TextBlock>
 
-                    <TextBox Name="StartDateEntryForm" AutomationProperties.Name="Start Date, Required" Grid.Row="3" Grid.Column="1"
+                    <TextBox Name="StartDateEntryForm" AutomationProperties.Name="Start Date" Grid.Row="3" Grid.Column="1"
                              Validation.ErrorTemplate="{StaticResource ValidationTemplate}"
                              Style="{StaticResource TextStyleTextBox}" Margin="8,5,0,5"
                              Validation.Error="OnValidationError"
+                             AutomationProperties.IsRequiredForForm="True"
                              AutomationProperties.LiveSetting="Assertive">
                         <TextBox.Text>
                             <Binding Path="StartDate" UpdateSourceTrigger="PropertyChanged"


### PR DESCRIPTION
Updates fix to issue #350 , done in the PR #351.

## Description

In the previous PR, the fields for Date and Price were changed to required. This PR changes the AutomationPorperties.IsRequiredForForm property to true, so the narrator can say this information in the correct language.

## Customer Impact

When using the sample app, the user would not know both Date and StartPrice are required.
## Regression

No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing

The sample project was tested using narrator to assert the informations are being said.
