### PR TITLE
Fixing bug 1159105 in samples used by accessibility test team.

### DIFF
--- a/Sample Applications/DataBindingDemo/AddProductWindow.cs
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.cs
@@ -15,8 +15,11 @@ namespace DataBindingDemo
     /// </summary>
     public partial class AddProductWindow : Window
     {
-        public AddProductWindow()
+        MainWindow mainWindow;
+
+        public AddProductWindow(MainWindow mainWindow)
         {
+            this.mainWindow = mainWindow;
             InitializeComponent();
         }
 
@@ -59,6 +62,7 @@ namespace DataBindingDemo
                 var item = (AuctionItem)(DataContext);
                 ((App) Application.Current).AuctionItems.Add(item);
                 Close();
+                mainWindow.FocusNewProduct();
             }
 
         }

--- a/Sample Applications/DataBindingDemo/MainWindow.cs
+++ b/Sample Applications/DataBindingDemo/MainWindow.cs
@@ -1,12 +1,15 @@
 ﻿// // Copyright (c) Microsoft. All rights reserved.
 // // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
+using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Input;
 
 namespace DataBindingDemo
 {
@@ -21,11 +24,12 @@ namespace DataBindingDemo
         {
             InitializeComponent();
             _listingDataView = (CollectionViewSource) (Resources["ListingDataView"]);
+            FocusManager.SetIsFocusScope(Master, true);
         }
 
         private void OpenAddProductWindow(object sender, RoutedEventArgs e)
         {
-            var addProductWindow = new AddProductWindow();
+            var addProductWindow = new AddProductWindow(this);
             addProductWindow.ShowDialog();
         }
 
@@ -88,6 +92,18 @@ namespace DataBindingDemo
         private void RemoveFiltering(object sender, RoutedEventArgs args)
         {
             _listingDataView.Filter -= ShowOnlyBargainsFilter;
+            NotifyUpdate();
+        }
+
+        public void FocusNewProduct()
+        {
+            int index = Master.Items.Count - 1;
+            Master.SelectedIndex = index;
+            AuctionItem SelectedItem = Master.SelectedItem as AuctionItem;
+            ListBoxItem listBoxItem = Master.Items.GetItemAt(index) as ListBoxItem;
+            FocusManager.SetFocusedElement(Master, listBoxItem);
+            Keyboard.Focus(Master);
+            Master.ScrollIntoView(SelectedItem);
             NotifyUpdate();
         }
     }


### PR DESCRIPTION
Fixes Issue #355.

## Description

When a new product is added, the opened window is closed but the narrator don't tell the status as the new product added. Now, when added, the focus is changed to the new product on the list, and the narrator tells the user about the list status, focusing on the new product.

## Customer Impact

Screenreader user unable to get the status message as content updated after selecting the the check box.

## Regression

No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing

The sample project was tested using narrator to assert the is status is now the new product added.
