### PR TITLE
Fixing bug 1260534 in samples used by accessibility test team

### DIFF
--- a/Sample Applications/ExpenseIt/ExpenseItDemo/MainWindow.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/MainWindow.xaml
@@ -149,7 +149,7 @@
                          Grid.Column="1" Grid.Row="4"
                          ItemTemplate="{StaticResource EmployeeItemTemplate}"
                          ItemsSource="{Binding Source={StaticResource Employees}}"
-                         ItemContainerStyle="{Binding Source={StaticResource EmployeeListItem}}"
+                         ItemContainerStyle="{StaticResource EmployeeListItemContainerStyle}"
                          AutomationProperties.Name="Employee Name">
                     <ListBox.ToolTip>
                         <TextBlock>Choose employee name.</TextBlock>

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/MainWindow.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/MainWindow.xaml
@@ -149,15 +149,11 @@
                          Grid.Column="1" Grid.Row="4"
                          ItemTemplate="{StaticResource EmployeeItemTemplate}"
                          ItemsSource="{Binding Source={StaticResource Employees}}"
+                         ItemContainerStyle="{Binding Source={StaticResource EmployeeListItem}}"
                          AutomationProperties.Name="Employee Name">
                     <ListBox.ToolTip>
                         <TextBlock>Choose employee name.</TextBlock>
                     </ListBox.ToolTip>
-                    <ListBox.ItemContainerStyle>
-                        <Style>
-                            <Setter Property="AutomationProperties.Name" Value="{Binding XPath=@Name}" />
-                        </Style>
-                    </ListBox.ItemContainerStyle>
                 </ListBox>
 
                 <!-- Create Expense Report -->

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
@@ -166,6 +166,28 @@
         <Setter Property="MinHeight" Value="50" />
     </Style>
 
+    <Style x:Key="EmployeeListItemFocus" TargetType="Control">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle StrokeThickness="1"
+                          Stroke="White"
+                          StrokeDashArray="1 2"
+                          SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="EmployeeListItem" TargetType="{x:Type ListBoxItem}">
+        <Setter Property="AutomationProperties.Name" Value="{Binding XPath=@Name}" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
+                <Setter Property="FocusVisualStyle" Value="{StaticResource EmployeeListItemFocus}"/>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
     <Style x:Key="CostCenterList" TargetType="{x:Type ComboBox}">
         <Setter Property="Margin" Value="0,5,5,0" />
     </Style>

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
@@ -166,24 +166,25 @@
         <Setter Property="MinHeight" Value="50" />
     </Style>
 
-    <Style x:Key="EmployeeListItemFocus" TargetType="Control">
+    <Style x:Key="EmployeeListHighContrastFocusVisualStyle" TargetType="Control">
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
                     <Rectangle StrokeThickness="1"
                           Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
                           StrokeDashArray="1 2"
+                          Margin="0,1,0,1"
                           SnapsToDevicePixels="true"/>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
-    <Style x:Key="EmployeeListItem" TargetType="{x:Type ListBoxItem}">
+    <Style x:Key="EmployeeListItemContainerStyle" TargetType="{x:Type ListBoxItem}">
         <Setter Property="AutomationProperties.Name" Value="{Binding XPath=@Name}" />
         <Style.Triggers>
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
-                <Setter Property="FocusVisualStyle" Value="{StaticResource EmployeeListItemFocus}"/>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource EmployeeListHighContrastFocusVisualStyle}"/>
             </DataTrigger>
         </Style.Triggers>
     </Style>

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
@@ -171,7 +171,7 @@
             <Setter.Value>
                 <ControlTemplate>
                     <Rectangle StrokeThickness="1"
-                          Stroke="White"
+                          Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
                           StrokeDashArray="1 2"
                           SnapsToDevicePixels="true"/>
                 </ControlTemplate>


### PR DESCRIPTION
Fixes issues #363.

## Description

When in High Contrast mode, if the user move the focus to the employees table using keyboard, they couldn't see any visual feedback. The color of the border stroke of the visual focus style was changed to White to match the colors needed.

## Customer Impact

When using the sample app in high constrast mode, the user will be able to see visual feedback when focusing the employees table.

## Regression

No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing

The sample project was tested using high contrast mode.
