### PR TITLE
Fixing bugs 1260528 and 1260525

### DIFF
--- a/Sample Applications/ExpenseIt/ExpenseItDemo/CreateExpenseReportDialogBox.cs
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/CreateExpenseReportDialogBox.cs
@@ -19,6 +19,14 @@ namespace ExpenseItDemo
         public CreateExpenseReportDialogBox()
         {
             InitializeComponent();
+
+            var app = Application.Current;
+            var expenseReport = (ExpenseReport) app.FindResource("ExpenseData");
+
+            if (expenseReport != null && !expenseReport.Initialized)
+            {
+                expenseReport.InitializeItems();
+            }
         }
 
         private void addExpenseButton_Click(object sender, RoutedEventArgs e)
@@ -26,7 +34,7 @@ namespace ExpenseItDemo
             var app = Application.Current;
             var expenseReport = (ExpenseReport) app.FindResource("ExpenseData");
             expenseReport?.LineItems.Add(new LineItem());
-            
+
             DataGridRow row =null;
 
             // Dispatching this at loaded priority so the new row has been added before our code runs

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/CreateExpenseReportDialogBox.cs
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/CreateExpenseReportDialogBox.cs
@@ -82,15 +82,37 @@ namespace ExpenseItDemo
             dlg.Show();
         }
 
+        bool isValid(DependencyObject parent)
+        {
+            if (System.Windows.Controls.Validation.GetHasError(parent)) return false;
+
+            for(int i = 0; i != VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                DependencyObject child = VisualTreeHelper.GetChild(parent, i);
+                if (!isValid(child)) return false;
+            }
+
+            return true;
+        }
+
         private void okButton_Click(object sender, RoutedEventArgs e)
         {
-            MessageBox.Show(
-                "Expense Report Created!",
-                "ExpenseIt Standalone",
-                MessageBoxButton.OK,
-                MessageBoxImage.Information);
+            if(!isValid(expenseDataGrid1)){
+                MessageBox.Show(
+                    "Please, fix the errors.",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            } else
+            {
+                MessageBox.Show(
+                    "Expense Report Created!",
+                    "ExpenseIt Standalone",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
 
-            DialogResult = true;
+                DialogResult = true;
+            }
         }
 
         private void cancelButton_Click(object sender, RoutedEventArgs e)

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/ExpenseReport.cs
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/ExpenseReport.cs
@@ -17,11 +17,18 @@ namespace ExpenseItDemo
         private string _costCenter;
         private string _employeeNumber;
         private int _totalExpenses;
+        private bool _initialized = false;
 
         public ExpenseReport()
         {
             LineItems = new LineItemCollection();
             LineItems.LineItemCostChanged += OnLineItemCostChanged;
+        }
+
+        public void InitializeItems()
+        {
+            LineItems.InitializeItems();
+            _initialized = true;
         }
 
         public string Alias
@@ -61,6 +68,14 @@ namespace ExpenseItDemo
             {
                 RecalculateTotalExpense();
                 return _totalExpenses;
+            }
+        }
+
+        public bool Initialized
+        {
+            get
+            {
+                return _initialized;
             }
         }
 

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/LineItemCollection.cs
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/LineItemCollection.cs
@@ -11,6 +11,14 @@ namespace ExpenseItDemo
     {
         public event EventHandler LineItemCostChanged;
 
+        public void InitializeItems()
+        {
+            for(int i = 0; i < Items.Count; i++)
+            {
+                Items[i].PropertyChanged += LineItemPropertyChanged;
+            }
+        }
+
         public new void Add(LineItem item)
         {
             if (item != null)

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
@@ -369,6 +369,7 @@
         <Setter Property="FontFamily" Value="Ariel" />
         <Setter Property="TextAlignment" Value="Center" />
         <Setter Property="TextTrimming" Value="WordEllipsis" />
+        <Setter Property="TextWrapping" Value="WrapWithOverflow" />
         <Setter Property="Width" Value="100" />
         <Style.Triggers>
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/ViewChartWindow.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/ViewChartWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:ExpenseItDemo"
+        DataContext="{StaticResource ExpenseData}"
         mc:Ignorable="d"
         Title="ViewChartWindow" Height="300" Width="300">
     <Grid Style="{StaticResource WindowContentGrid}">


### PR DESCRIPTION
Fixes issues #362 and #361.

## Description

This fix changes two bugs related above. The first is the expense report being generated successful even when there are errors in the table. A method was addet to check if there exists any error in the expenses table and show an error message box if there is one. The second one is that the graph char window doesn't show the expense report total value and the text was being clipped. To fix the text, it was changed to wrap, and to fix the value not showing, the ExpenseData declared as the DataContext of the page.

Actually, there was another bug in the app. When changing the value of the items that are in the table since beggining, the total expense was not changing. This is because the parent list didn't subscribe to their property change events. So now there is an InitializeItms function that is called once and do these subscriptions.

## Customer Impact

When using the app, the customer will now see that the table has an error when they try to generete the expense report. And now the total expense value is being updated correctly everywhere.

## Regression

No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing

The sample project was tested by its usage.
