### PR TITLE
Fixing bugs 1260517 and 1260519 in samples used by accessibility test team.

### DIFF
--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
@@ -51,13 +51,14 @@
             <!-- Name -->
             <StackPanel Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Orientation="Horizontal">
                 <Label Style="{StaticResource LabelStyle}">Name:</Label>
-                <Label x:Name="NameLiveRegion" AutomationProperties.LiveSetting="Assertive" Style="{StaticResource LabelStyle}" Content="{Binding XPath=@Name}"></Label>
+                <Label x:Name="NameLiveRegion" AutomationProperties.LiveSetting="Assertive" Style="{StaticResource LabelStyle}"
+                       Content="{Binding XPath=@Name}" AutomationProperties.Name="{Binding XPath=@Name}"></Label>
             </StackPanel>
 
             <!-- Department -->
             <StackPanel Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" Orientation="Horizontal">
                 <Label Style="{StaticResource LabelStyle}">Department:</Label>
-                <Label Style="{StaticResource LabelStyle}" Content="{Binding XPath=@Department}"></Label>
+                <Label Style="{StaticResource LabelStyle}" Content="{Binding XPath=@Department}" AutomationProperties.Name="{Binding XPath=@Department}"></Label>
             </StackPanel>
             <Grid Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Left">
 

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
@@ -63,7 +63,7 @@
             <Grid Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Left">
 
                 <!-- Expense type and Amount table -->
-                <DataGrid AutomationProperties.Name="Expense report" ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" RowHeaderWidth="0" CanUserResizeColumns="False" CanUserResizeRows="False" >
+                <DataGrid AutomationProperties.Name="Expense report" ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" HeadersVisibility="Column" CanUserResizeColumns="False" CanUserResizeRows="False" >
                     <DataGrid.Resources>
                         <!--
                             When using XmlDataProvider, we need to ensure the DataGridRow properly sets the automation name


### PR DESCRIPTION
Fixes issues #359 and #358.

## Description

The narrator was saying the name of the person with xaml tags. So the AutomationProperties.Name was set to the Name property so it says correctly. The same issue was happening in the department field, so the same fix was applyied.

Also, there as the "invisible" header that could be accessed by keyboard navigation. So instead of having a zero-sized header, the header was removed.

## Customer Impact

When using the sample app, the narrator will say the name and department correctly without the xaml tags, that could cause confusion in users. And the invisible header was removed that could also cause confusion.

## Regression

No. This sample is used for Accessibility testing and never fully supported Narrator.

## Testing

The sample project was tested using narrator to assert the informations are being said correctly.
