### PR TITLE
Fixing Bug 1260517 in WPF Sample

### DIFF
--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
@@ -51,18 +51,18 @@
             <!-- Name -->
             <StackPanel Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Orientation="Horizontal">
                 <Label Style="{StaticResource LabelStyle}">Name:</Label>
-                <Label x:Name="NameLiveRegion" AutomationProperties.LiveSetting="Assertive" Style="{StaticResource LabelStyle}" Content="{Binding XPath=@Name, Path=Value}"></Label>
+                <Label x:Name="NameLiveRegion" AutomationProperties.LiveSetting="Assertive" Style="{StaticResource LabelStyle}" AutomationProperties.Name="{Binding XPath=@Name}" Content="{Binding XPath=@Name}"></Label>
             </StackPanel>
 
             <!-- Department -->
             <StackPanel Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" Orientation="Horizontal">
                 <Label Style="{StaticResource LabelStyle}">Department:</Label>
-                <Label Style="{StaticResource LabelStyle}" Content="{Binding XPath=@Department}"></Label>
+                <Label x:Name="DepartmentLiveRegion" AutomationProperties.LiveSetting="Assertive" Style="{StaticResource LabelStyle}" Content="{Binding XPath=@Department}" AutomationProperties.Name="{Binding XPath=@Department}"></Label>
             </StackPanel>
             <Grid Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Left">
 
                 <!-- Expense type and Amount table -->
-                <DataGrid AutomationProperties.Name="Expense report" ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" RowHeaderWidth="0" CanUserResizeColumns="False" CanUserResizeRows="False" >
+                <DataGrid AutomationProperties.Name="Expense report" ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" HeadersVisibility="Column" CanUserResizeColumns="False" CanUserResizeRows="False" >
                     <DataGrid.Resources>
                         <!--
                             When using XmlDataProvider, we need to ensure the DataGridRow properly sets the automation name

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
@@ -51,7 +51,7 @@
             <!-- Name -->
             <StackPanel Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Orientation="Horizontal">
                 <Label Style="{StaticResource LabelStyle}">Name:</Label>
-                <Label x:Name="NameLiveRegion" AutomationProperties.LiveSetting="Assertive" Style="{StaticResource LabelStyle}" Content="{Binding XPath=@Name}"></Label>
+                <Label x:Name="NameLiveRegion" AutomationProperties.LiveSetting="Assertive" Style="{StaticResource LabelStyle}" Content="{Binding XPath=@Name, Path=Value}"></Label>
             </StackPanel>
 
             <!-- Department -->

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml.cs
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml.cs
@@ -29,6 +29,7 @@ namespace ExpenseIt
             // the report for.
             FrameworkElementAutomationPeer.FromElement(LiveRegion)?.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
             FrameworkElementAutomationPeer.FromElement(NameLiveRegion)?.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+            FrameworkElementAutomationPeer.FromElement(DepartmentLiveRegion)?.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
         }
     }
   


### PR DESCRIPTION
Fixes issue #358 

**Description:**
 An extra text element 'system.Xml.Xmlattribute' is defined in the
 hierarchy before the name of the user in Expense View report.

**Actual Behaviour:**
When the Expense report for window is opened narrator announces as 'Expense report for system.xml.xmlattribute<name>'. Here 'system.xml.xmlattribute' is an extra text element that is defined in the hierarchy which doesn't convey any useful information to the user.

**Expected Behaviour:**
The extra text element 'system.xml.xmlattribute' should not be defined in the hierarchy as it is not conveying any useful information to the user. Narrator should announce as Expense report window for <Name>Mike.

**User Impact:**
Screen reader users will not be able to understand the context and purpose if Narrator is announcing as 'system.xml.xmlattribute' which doesn't convey any useful information to the user. 

**Cause:**
Narrator was reading object type and value of the XML node.

**Fix:**
Value of Label has to be passed in the binding.

**Regression**
No. This sample is used for Accessibility testing and never fully supported Narrator.

**Testing**
The sample project was tested using Narrator to confirm that XML object description is not narrated.
