### PR TITLE
Fixing Bug: 1260519  in Samples used by Accessibility team for testing.

### DIFF
--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
@@ -62,7 +62,7 @@
             <Grid Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Left">
 
                 <!-- Expense type and Amount table -->
-                <DataGrid AutomationProperties.Name="Expense report" ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" RowHeaderWidth="0" CanUserResizeColumns="False" CanUserResizeRows="False" >
+                <DataGrid AutomationProperties.Name="Expense report" ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" RowHeaderWidth="0" CanUserResizeColumns="False" CanUserResizeRows="False" HeadersVisibility="Column">
                     <DataGrid.Resources>
                         <!--
                             When using XmlDataProvider, we need to ensure the DataGridRow properly sets the automation name


### PR DESCRIPTION
An extra header item is defined under each Data Grid.

Actual result:
While user consuming the table contents after navigating to the complete row, if we Caps+Right Arrow key, narrator is nowhere visible and it announces as header item which is not visually available. This issue is observed only when navigated using caps+Arrow keys. With tab navigation announcement is proper.
Two extra header items are defined under each Datagrid row in the hierarchy.

Expected Result:
Narrator should not announce any extra header item which is not even available visually.

Cause:
Narrator was reading extra header item because of row header.

Fix:
Change the header visibility to column.

Customer Impact
Screen reader reads Extra header item for Row which is not even available visually.

Regression
No. This sample is used for Accessibility testing and never fully supported Narrator.

Testing
The sample project was tested using Narrator to confirm that no extra header item is narrated.