### PR TITLE
Fixing Bug 1159083 in WPF Sample

### DIFF
--- a/Sample Applications/CustomComboBox/MainWindow.xaml
+++ b/Sample Applications/CustomComboBox/MainWindow.xaml
@@ -21,7 +21,7 @@
                              ItemsSource="{Binding Movies}" Command="{Binding OnWatchNow}" 
                              ItemContainerStyle="{StaticResource MovieItemContainerStyle}"
                              DisplayMemberPath="Title"
-                             IsTabStop="False"/>
+                             IsTabStop="False" Width="160"/>
 
         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
             <TextBlock Text="{Binding SelectedMovie, Converter={StaticResource stringConverter}, ConverterParameter=text, NotifyOnTargetUpdated=True}" Style="{DynamicResource streamingTextStyle}" TargetUpdated="TextBlock_TargetUpdated" AutomationProperties.LiveSetting="Assertive"/>

--- a/Sample Applications/CustomComboBox/Styles.xaml
+++ b/Sample Applications/CustomComboBox/Styles.xaml
@@ -339,7 +339,7 @@
                                      ItemContainerStyle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ItemContainerStyle}"
                                      DisplayMemberPath="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMemberPath}" 
                                      SelectedValuePath="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMemberPath}"
-                                     TabIndex="1">
+                                     TabIndex="1" Visibility="Collapsed">
                             <ListBox.Resources>
                                 <Style TargetType="ScrollBar" BasedOn="{StaticResource ScrollBarStyle}" />
                                 <Style TargetType="ListBoxItem" BasedOn="{StaticResource ListBoxItemStyle}" />
@@ -350,6 +350,9 @@
                             <EventTrigger RoutedEvent="local:ExpandableToggleButton.Expanded">
                                 <BeginStoryboard>
                                     <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="lstBx" Storyboard.TargetProperty="Visibility">
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.0" Value="{x:Static Visibility.Visible}"/>
+                                        </ObjectAnimationUsingKeyFrames>
                                         <DoubleAnimation Storyboard.TargetName="lstBx" Storyboard.TargetProperty="Height" From="0" To="60" Duration="0:0:0.5"/>
                                         <BooleanAnimationUsingKeyFrames Storyboard.TargetName="lstBx" Storyboard.TargetProperty="Focusable">
                                             <DiscreteBooleanKeyFrame KeyTime="00:00:00" Value="True"/>
@@ -360,6 +363,9 @@
                             <EventTrigger RoutedEvent="local:ExpandableToggleButton.Collapsed">
                                 <BeginStoryboard>
                                     <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="lstBx" Storyboard.TargetProperty="Visibility">
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.5" Value="{x:Static Visibility.Collapsed}"/>
+                                        </ObjectAnimationUsingKeyFrames>
                                         <DoubleAnimation Storyboard.TargetName="lstBx" Storyboard.TargetProperty="Height" From="60" To="0" Duration="0:0:0.5"/>
                                         <BooleanAnimationUsingKeyFrames Storyboard.TargetName="lstBx" Storyboard.TargetProperty="Focusable">
                                             <DiscreteBooleanKeyFrame KeyTime="00:00:00" Value="False"/>


### PR DESCRIPTION
Fix for issue #373 and #334
### Environment Details:
Application Name: .NETCore WPF
Microsoft .NET Core SDK Version 5.1.20.33018


Microsoft .NET Core SDK 3.1.400 - preview (x86)
Visual Studio 2019 INT Preview 16.7 Preview 4

Screen reader: Narrator,NVDA[2020.1]

 

### Prerequisite:
To use the samples with Git, clone the WPF-Samples repository with 'git clone https://github.com/microsoft/WPF-Samples'
After cloning the WPF-Samples repository, please open the solution file, WPF-Samples.sln in the root directory.
To build the samples, open the solution file in Visual Studio 2019 and build the specific project you’re interested in. You can then right-click on the project file and select Debug -> Start new instance to run the application
 

### Steps to Reproduce:
Launch VS 2019 Int Preview
Navigate to Sample Applications and right click on the Custom Combo box and click on build.
Then right click on Custom Combo box then Click on Debug-->Start New Instance.
Main Window screen should open.
Navigate to the list of movies and select any movies by navigating through arrow key.
Check whether the screen reader reads all the drop down list items are announced despite of them being not displayed.

### Actual:
While navigating through caps lock+arrow key, All the drop down list items are announced despite of them being not displayed.

Similar issue observed using NVDA screen reader.



### Expected:
Screen reader should not read all the drop down list items as those are not displayed.



### User Impact:
Screen reader user will get confuse if the hidden content reads.



### Recommendations:
Refer repository of bug fixes code snippets.



### MAS Reference:
MAS 1.3.1 - Info and Relationships