### PR TITLE
Add CODEOWNERS file that automatically includes @dotnet/wpf-developers as reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo,
+# and will automatically be added as reviewers to all pull requests.
+*       @dotnet/wpf-developers


### PR DESCRIPTION
Add CODEOWNERS file that automatically includes @dotnet/wpf-developers as reviewers on all PRs.  (Copied from the WPF repo.)

/cc @SamBent