### PR TITLE
Fixing Bug: 1260528 (#378) in Samples used by Accessibility team for testing.

### DIFF
--- a/Sample Applications/DataBindingDemo/Styles.xaml
+++ b/Sample Applications/DataBindingDemo/Styles.xaml
@@ -86,6 +86,15 @@
                     <Setter Property="TextBlock.Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
                 </MultiDataTrigger.Setters>
             </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true" />
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="true" />
+                </MultiDataTrigger.Conditions>
+                <MultiDataTrigger.Setters>
+                    <Setter Property="TextBlock.Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+                </MultiDataTrigger.Setters>
+            </MultiDataTrigger>
         </Style.Triggers>
     </Style>
 


### PR DESCRIPTION
### Description
The foreground was not getting changed on keyboard focus.
Created a new multi data trigger condition to handle the high contrast and keyboard focus.

### Customer Impact
Low vision users will find difficulty in knowing the list items in the drop down.

### Regression
No.

### Testing
The sample project was tested to show the drop down items clearly in high contras mode white.