### PR TITLE
Fixing Bug: 1333465 (#380) in Samples used by Accessibility team for testing. 

### DIFF
--- a/Sample Applications/EditingExaminerDemo/MainWindow.xaml
+++ b/Sample Applications/EditingExaminerDemo/MainWindow.xaml
@@ -28,7 +28,7 @@
                             <FlowDocument
                                 ColumnWidth="400" AutomationProperties.Name="Help Text"
                                 IsOptimalParagraphEnabled="True" IsHyphenationEnabled="True">
-                                <Section FontSize="12">
+                                <Section FontSize="12" Style="{StaticResource HelpSectionTextHighContrastStyle}">
                                     <Paragraph FontSize="22" FontWeight="Bold">Introducing Editing Examiner</Paragraph>
 
                                     <Paragraph>

--- a/Sample Applications/EditingExaminerDemo/Styles.xaml
+++ b/Sample Applications/EditingExaminerDemo/Styles.xaml
@@ -58,4 +58,11 @@
             </Setter.Value>
         </Setter>
     </Style>
+    <Style x:Key="HelpSectionTextHighContrastStyle" TargetType="Section">
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true" >
+                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
 </ResourceDictionary>


### PR DESCRIPTION
### Description
The foreground was not getting changed on keyboard focus.
Created a new data trigger condition to handle the high contrast mode.

### Customer Impact
Low vision users will find difficulty in reading the help text in high contrast mode black.

### Regression
No.

### Testing
The sample project was tested to show the Help text clearly in high contrast mode black.