### PR TITLE
Fixing bug 1260522 in WPF-Samples used by Accessibility Team

### DIFF
--- a/Sample Applications/ExpenseIt/ExpenseItDemo/MainWindow.cs
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/MainWindow.cs
@@ -18,15 +18,14 @@ namespace ExpenseItDemo
         static MainWindow()
         {
             // Define CreateExpenseReportCommand
-            CreateExpenseReportCommand = new RoutedUICommand("_Create Expense Report...", "CreateExpenseReport",
-                typeof (MainWindow));
+            CreateExpenseReportCommand = new RoutedUICommand("_Create Expense Report..." ,"CreateExpenseReport", typeof(MainWindow));
             CreateExpenseReportCommand.InputGestures.Add(new KeyGesture(Key.C, ModifierKeys.Control | ModifierKeys.Shift));
 
             // Define ExitCommand
-            ExitCommand = new RoutedUICommand("E_xit", "Exit", typeof (MainWindow));
+            ExitCommand = new RoutedUICommand("E_xit", "Exit", typeof(MainWindow));
 
             // Define AboutCommand
-            AboutCommand = new RoutedUICommand("_About ExpenseIt Standalone", "About", typeof (MainWindow));
+            AboutCommand = new RoutedUICommand("_About ExpenseIt Standalone", "About", typeof(MainWindow));
         }
 
         public MainWindow()

--- a/Sample Applications/ExpenseIt/ExpenseItDemo/MainWindow.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/MainWindow.xaml
@@ -32,14 +32,14 @@
 
                 <!-- File Menu-->
                 <MenuItem Header="_File">
-                    <MenuItem Command="local:MainWindow.CreateExpenseReportCommand" />
+                    <MenuItem Command="local:MainWindow.CreateExpenseReportCommand"/>
                     <Separator />
-                    <MenuItem Command="local:MainWindow.ExitCommand" />
+                    <MenuItem Command="local:MainWindow.ExitCommand"/>
                 </MenuItem>
 
                 <!-- Help Menu-->
                 <MenuItem Header="_Help">
-                    <MenuItem Command="local:MainWindow.AboutCommand" />
+                    <MenuItem Command="local:MainWindow.AboutCommand"/>
                 </MenuItem>
 
             </Menu>
@@ -142,7 +142,7 @@
                             <TextBlock>Vendor employee type</TextBlock>
                         </ListBoxItem.ToolTip>
                     </ListBoxItem>
-                </ListBox>
+                </ListBox>  
 
                 <!-- Employee List -->
                 <ListBox Style="{StaticResource EmployeeList}"
@@ -158,10 +158,11 @@
 
                 <!-- Create Expense Report -->
                 <Button Name="createExpenseReportButton" Style="{StaticResource CommandButton}" Grid.Column="1"
-                        Grid.Row="5" Command="local:MainWindow.CreateExpenseReportCommand">
+                        Grid.Row="5" Command="local:MainWindow.CreateExpenseReportCommand"
+                        AutomationProperties.AcceleratorKey="Ctrl+Shift+C">
                     Create Expense _Report
                     <Button.ToolTip>
-                        <TextBlock>Create Expense Report.</TextBlock>
+                        <TextBlock>Opens a dialog for creating expense report</TextBlock>
                     </Button.ToolTip>
                 </Button>
 


### PR DESCRIPTION
This PR fixes issue #382 

## Description
**Sample Application :** ExpenseItDemo
Extra information was being announced when we navigated to the 'Create Expense Report' button.

### Customer Impact
Screen reader users will not be able to understand if narrator announces improper information.

### Regression 
No

### Testing
The sample application was tested to check that : 

- Extra information is not being announced by the narrator when we navigate to the button.
- Changes to the commands, does not affect the use of access keys for the menu items. 