### PR TITLE
Linguist tool configuration: exclude RTF from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,8 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+###############################################################################
+# Linguist tool configuration: exclude RTF from language stats
+###############################################################################
+*.rtf linguist-vendored


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/19646569/125085743-1e022b00-e0f5-11eb-878d-dd8000deadee.png)

After:

![image](https://user-images.githubusercontent.com/19646569/125085902-49851580-e0f5-11eb-97b5-88b4006e4b41.png)
