### PR TITLE
Update release/3.1 pipeline to only build 3.1.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,11 +3,9 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="myget-fxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
     <add key="arcade" value="https://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
-    <add key="myget-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-wd" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
     <add key="aspnet-core" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,60 +42,30 @@ stages:
         _Platform: 'Any CPU'
         _TargetFramework: 'netcoreapp3.1'
         _ToolPlatform: x86
-      Debug-AnyCPU-net5.0:
-        _Configuration: Debug
-        _Platform: 'Any CPU'
-        _TargetFramework: 'net5.0'
-        _ToolPlatform: x86
       Debug-x64-netcoreapp3.1:
         _Configuration: Debug
         _Platform: 'x64'
         _TargetFramework: 'netcoreapp3.1'
-        _ToolPlatform: x64
-      Debug-x64-net5.0:
-        _Configuration: Debug
-        _Platform: 'x64'
-        _TargetFramework: 'net5.0'
         _ToolPlatform: x64
       Debug-x86-netcoreapp3.1:
         _Configuration: Debug
         _Platform: 'x86'
         _TargetFramework: 'netcoreapp3.1'
         _ToolPlatform: x86
-      Debug-x86-net5.0:
-        _Configuration: Debug
-        _Platform: 'x86'
-        _TargetFramework: 'net5.0'
-        _ToolPlatform: x86
       Release-AnyCPU-netcoreapp3.1:
         _Configuration: Release
         _Platform: 'Any CPU'
         _TargetFramework: 'netcoreapp3.1'
-        _ToolPlatform: x86
-      Release-AnyCPU-net5.0:
-        _Configuration: Release
-        _Platform: 'Any CPU'
-        _TargetFramework: 'net5.0'
         _ToolPlatform: x86
       Release-x64-netcoreapp3.1:
         _Configuration: Release
         _Platform: 'x64'
         _TargetFramework: 'netcoreapp3.1'
         _ToolPlatform: x64
-      Release-x64-net5.0:
-        _Configuration: Release
-        _Platform: 'x64'
-        _TargetFramework: 'net5.0'
-        _ToolPlatform: x64
       Release-x86-netcoreapp3.1:
         _Configuration: Release
         _Platform: 'x86'
         _TargetFramework: 'netcoreapp3.1'
-        _ToolPlatform: x86
-      Release-x86-net5.0:
-        _Configuration: Release
-        _Platform: 'x86'
-        _TargetFramework: 'net5.0'
         _ToolPlatform: x86
     steps:
      - task: NuGetToolInstaller@1


### PR DESCRIPTION
We now have three separate branches for each target framework: main targeting .NET 6, release/5.0 targeting .NET 5, and release/3.1 targeting .NET 3.1.  Update release/3.1 pipeline to only build 3.1.