### PR TITLE
Updated NuGet config to include MyGet packages feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,6 +7,7 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+	<add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     <add key="dotnet-wd" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
     <add key="aspnet-core" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
 	<add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,10 +7,10 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-	  <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     <add key="dotnet-wd" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
     <add key="aspnet-core" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
-	  <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="dotnet5-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,10 +7,10 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-	<add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+	  <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     <add key="dotnet-wd" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
     <add key="aspnet-core" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
-	<add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+	  <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="dotnet5-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />


### PR DESCRIPTION
## Description
The NuGet config file in WPF-Samples contain the following entry :
`
<add key="myget-fxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
`

However, as per github issue: [link](https://github.com/dotnet/aspnetcore/issues/29207) this old feeds have been replaced with new feed:
`
https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json
`

### Regression
No