### PR TITLE
Fix #5042 : An onscreen element must not have a null BoundingRectangle property.

### DIFF
--- a/Sample Applications/CustomComboBox/MainWindow.xaml
+++ b/Sample Applications/CustomComboBox/MainWindow.xaml
@@ -25,7 +25,7 @@
 
         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
             <TextBlock Text="{Binding SelectedMovie, Converter={StaticResource stringConverter}, ConverterParameter=text, NotifyOnTargetUpdated=True}" Style="{DynamicResource streamingTextStyle}" TargetUpdated="TextBlock_TargetUpdated" AutomationProperties.LiveSetting="Assertive"/>
-            <TextBlock Text="{Binding SelectedMovie, NotifyOnTargetUpdated=True}" HorizontalAlignment="Center" TargetUpdated="TextBlock_TargetUpdated" AutomationProperties.LiveSetting="Assertive"/>
+            <TextBlock Text="{Binding SelectedMovie, NotifyOnTargetUpdated=True}" HorizontalAlignment="Center" TargetUpdated="TextBlock_TargetUpdated" AutomationProperties.LiveSetting="Assertive" Style="{DynamicResource selectedMovieTextStyle}"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/Sample Applications/CustomComboBox/Styles.xaml
+++ b/Sample Applications/CustomComboBox/Styles.xaml
@@ -399,4 +399,12 @@
             </DataTrigger>
         </Style.Triggers>
     </Style>
+
+    <Style x:Key="selectedMovieTextStyle" TargetType="TextBlock">
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=SelectedMovie}" Value="{x:Null}">
+                <Setter Property="Visibility" Value="Collapsed"/>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
 </ResourceDictionary>


### PR DESCRIPTION
Fixes Issue #397 

### Description
An onscreen element must not have a null BoundingRectangle property.  [Section 508 502.3.1](https://www.access-board.gov/ict/#502-interoperability-assistive-technology) 

### Repro Steps

1. Launch VS 2019 Int Preview
2. Navigate to Sample Applications and right click on the Custom Combo box and click on build.
3. Then right click on Custom Combo box then Click on Debug-->Start New Instance.
4. Main Window screen should open.
5. Run accessibility Insights for windows tool

### Customer Impact
BoundingRectangle property set to - Property does not exist.

### Regression
No

### Testing
Build and verify the fix.