### PR TITLE
Fixing Accessibility Bug in WPF Sample(#5403)

### DIFF
--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
@@ -62,7 +62,7 @@
             <Grid Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Left">
 
                 <!-- Expense type and Amount table -->
-                <DataGrid AutomationProperties.Name="Expense report" ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" HeadersVisibility="Column" CanUserResizeColumns="False" CanUserResizeRows="False" >
+                <DataGrid BorderThickness="2" BorderBrush="Black" AutomationProperties.Name="Expense report" ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" HeadersVisibility="Column" CanUserResizeColumns="False" CanUserResizeRows="False" >
                     <DataGrid.Resources>
                         <!--
                             When using XmlDataProvider, we need to ensure the DataGridRow properly sets the automation name

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/Styles.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/Styles.xaml
@@ -8,7 +8,7 @@
         <Setter Property="Label.FontFamily" Value="Trebuchet MS"></Setter>
         <Setter Property="Label.FontWeight" Value="Bold"></Setter>
         <Setter Property="Label.FontSize" Value="18"></Setter>
-        <Setter Property="Label.Foreground" Value="#0066cc"></Setter>
+        <Setter Property="Label.Foreground" Value="#183862"></Setter>
         <Style.Triggers>
             <!-- When in high contrast modes, follow system colors to present proper contrast between adjacent colors. -->
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
@@ -37,7 +37,7 @@
     <Style x:Key="ListHeaderStyle" TargetType="{x:Type Border}">
         <Setter Property="Height" Value="35" />
         <Setter Property="Padding" Value="5" />
-        <Setter Property="Background" Value="#4E87D4" />
+        <Setter Property="Background" Value="#3274CD" />
         <Style.Triggers>
             <!-- When in high contrast modes, follow system colors to present proper contrast between adjacent colors. -->
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
@@ -50,7 +50,7 @@
     <Style x:Key="ColumnHeaderStyle" TargetType="{x:Type DataGridColumnHeader}">
         <Setter Property="Height" Value="35" />
         <Setter Property="Padding" Value="5" />
-        <Setter Property="Background" Value="#4E87D4" />
+        <Setter Property="Background" Value="#3274CD" />
         <Setter Property="Foreground" Value="White" />
         <Style.Triggers>
             <!-- 

--- a/Sample Applications/DataBindingDemo/Styles.xaml
+++ b/Sample Applications/DataBindingDemo/Styles.xaml
@@ -22,7 +22,7 @@
 
     <Style x:Key="SmallTitleStyle" TargetType="TextBlock">
         <Setter Property="FontWeight" Value="Bold" />
-        <Setter Property="Foreground" Value="DimGray" />
+        <Setter Property="Foreground" Value="Black" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalAlignment" Value="Right" />
         <Style.Triggers>
@@ -34,7 +34,7 @@
     </Style>
 
     <Style x:Key="TextStyleTextBlock" TargetType="TextBlock">
-        <Setter Property="Foreground" Value="#333333" />
+        <Setter Property="Foreground" Value="Black" />
         <Style.Triggers>
              <!--High contrast support--> 
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true" >
@@ -119,7 +119,7 @@
 
     <Style x:Key="AuctionItemBorderStyle" TargetType="Border">
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="BorderBrush" Value="Gray" />
+        <Setter Property="BorderBrush" Value="Black" />
         <Setter Property="Padding" Value="7" />
         <Setter Property="Margin" Value="3" />
         <Setter Property="Width" Value="500" />


### PR DESCRIPTION
### Environment details:
Application Name: .NET Core WPF
Microsoft .NET Core SDK Version 6.0.100-rc.1.21380.2
Windows Version: Windows10

### Repro Steps:

1. Launch VS 2019 Int Preview.
2. Navigate to Getting started and right click on the Expense it intro and navigate to build
3. Then navigate on Expense it Intro then Click on Debug-->Start New Instance.
4. Check whether the "view expense report" title and the background color contrast is 4.5:1 or not.
### Actual Result:
The "view expense report" title and its background color contrast is less than 4.5:1, i.e 3.981:1

### Note:
The same issue is reproducing in

the table control, "names" and its background, the ratio is 3.658:1
ExpenseItIntro->Expense report for-Color contrast is failing for table and overall background.
ExpenseItIntro->Expense report for-Color contrast for letters in the table and the blue background is failing.
DataBindingDemo->List of products-color contrast for the given highlighted colors is not compliant to the existing ratio.
### Expected Result:
The color contrast ration between title "View expense report" and background should be greater than or equal to 4.5:1"

### User Impact:
Low Vision users may find difficulty in reading the text.