### PR TITLE
5037 error message text box accessibility bug

### DIFF
--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseReportPage.xaml
@@ -62,7 +62,7 @@
             <Grid Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Left">
 
                 <!-- Expense type and Amount table -->
-                <DataGrid AutomationProperties.Name="Expense report" ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" HeadersVisibility="Column" CanUserResizeColumns="False" CanUserResizeRows="False" >
+                <DataGrid BorderThickness="2" BorderBrush="Black" AutomationProperties.Name="Expense report" ItemsSource="{Binding XPath=Expense}" ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}" AutoGenerateColumns="False" HeadersVisibility="Column" CanUserResizeColumns="False" CanUserResizeRows="False" >
                     <DataGrid.Resources>
                         <!--
                             When using XmlDataProvider, we need to ensure the DataGridRow properly sets the automation name

--- a/Getting Started/WalkthroughFirstWPFApp/csharp/Styles.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/Styles.xaml
@@ -8,7 +8,7 @@
         <Setter Property="Label.FontFamily" Value="Trebuchet MS"></Setter>
         <Setter Property="Label.FontWeight" Value="Bold"></Setter>
         <Setter Property="Label.FontSize" Value="18"></Setter>
-        <Setter Property="Label.Foreground" Value="#0066cc"></Setter>
+        <Setter Property="Label.Foreground" Value="#183862"></Setter>
         <Style.Triggers>
             <!-- When in high contrast modes, follow system colors to present proper contrast between adjacent colors. -->
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
@@ -37,7 +37,7 @@
     <Style x:Key="ListHeaderStyle" TargetType="{x:Type Border}">
         <Setter Property="Height" Value="35" />
         <Setter Property="Padding" Value="5" />
-        <Setter Property="Background" Value="#4E87D4" />
+        <Setter Property="Background" Value="#3274CD" />
         <Style.Triggers>
             <!-- When in high contrast modes, follow system colors to present proper contrast between adjacent colors. -->
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
@@ -50,7 +50,7 @@
     <Style x:Key="ColumnHeaderStyle" TargetType="{x:Type DataGridColumnHeader}">
         <Setter Property="Height" Value="35" />
         <Setter Property="Padding" Value="5" />
-        <Setter Property="Background" Value="#4E87D4" />
+        <Setter Property="Background" Value="#3274CD" />
         <Setter Property="Foreground" Value="White" />
         <Style.Triggers>
             <!-- 

--- a/Sample Applications/DataBindingDemo/Styles.xaml
+++ b/Sample Applications/DataBindingDemo/Styles.xaml
@@ -22,7 +22,7 @@
 
     <Style x:Key="SmallTitleStyle" TargetType="TextBlock">
         <Setter Property="FontWeight" Value="Bold" />
-        <Setter Property="Foreground" Value="DimGray" />
+        <Setter Property="Foreground" Value="Black" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalAlignment" Value="Right" />
         <Style.Triggers>
@@ -34,7 +34,7 @@
     </Style>
 
     <Style x:Key="TextStyleTextBlock" TargetType="TextBlock">
-        <Setter Property="Foreground" Value="#333333" />
+        <Setter Property="Foreground" Value="Black" />
         <Style.Triggers>
              <!--High contrast support--> 
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true" >
@@ -119,7 +119,7 @@
 
     <Style x:Key="AuctionItemBorderStyle" TargetType="Border">
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="BorderBrush" Value="Gray" />
+        <Setter Property="BorderBrush" Value="Black" />
         <Setter Property="Padding" Value="7" />
         <Setter Property="Margin" Value="3" />
         <Setter Property="Width" Value="500" />

--- a/Sample Applications/EditingExaminerDemo/Styles.xaml
+++ b/Sample Applications/EditingExaminerDemo/Styles.xaml
@@ -9,13 +9,14 @@
     <Style x:Key="ErrorMessageTextBox" TargetType="TextBox">
         <Setter Property="Foreground" Value="DarkRed" />
         <Setter Property="BorderBrush" Value="Red" />
+        <Setter Property="VerticalAlignment" Value="Center" />
 
         <Style.Triggers>
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}"/>
                 <Setter Property="FontWeight" Value="Bold"/>
                 <Setter Property="FontSize" Value="14"/>
-                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
                 <Setter Property="BorderThickness" Value="4" />
             </DataTrigger>
         </Style.Triggers>


### PR DESCRIPTION
Fix for #5037
### **Environment details:**

Application Name: .NET Core WPF
Microsoft .NET Core SDK Version 6.0.100-rc.1.21380.2
Windows Version: Windows10

### **Repro Steps**

1. Launch VS 2019 Int Preview
2. Tab and Navigate to Sample Applications and right click on the Editing Examiner Demo and click on build.
3..Then right click on Editing Examiner Demo then Click on Debug-->Start New Instance. 
4..Edit Examiner screen should open.
5.Tab and navigate till Immediate Window Control.
6. Tab and Navigate to "No Exception!" control below immediate Window control
7. Turn on High Contrast both High contrast black and high contrast white mode and bring the focus over the control.

### **Actual Result:**
At high contrast black and also in high contrast white, focus is not visible in "No exception! Warning Box"

### **Expected result:**
At high contrast black and also in high contrast white, focus should be visible in "No exception! Warning Box"

### **User Impact**:
Low Vision users may find difficulty in understanding where the focus currently is.