### PR TITLE
5043 color contrast exception box accessibility bug

### DIFF
--- a/Sample Applications/EditingExaminerDemo/Styles.xaml
+++ b/Sample Applications/EditingExaminerDemo/Styles.xaml
@@ -9,13 +9,14 @@
     <Style x:Key="ErrorMessageTextBox" TargetType="TextBox">
         <Setter Property="Foreground" Value="DarkRed" />
         <Setter Property="BorderBrush" Value="Red" />
+        <Setter Property="VerticalAlignment" Value="Center" />
 
         <Style.Triggers>
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}"/>
                 <Setter Property="FontWeight" Value="Bold"/>
                 <Setter Property="FontSize" Value="14"/>
-                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
                 <Setter Property="BorderThickness" Value="4" />
             </DataTrigger>
         </Style.Triggers>

--- a/Sample Applications/EditingExaminerDemo/Styles.xaml
+++ b/Sample Applications/EditingExaminerDemo/Styles.xaml
@@ -9,7 +9,6 @@
     <Style x:Key="ErrorMessageTextBox" TargetType="TextBox">
         <Setter Property="Foreground" Value="DarkRed" />
         <Setter Property="BorderBrush" Value="Red" />
-        <Setter Property="VerticalAlignment" Value="Center" />
 
         <Style.Triggers>
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
@@ -18,7 +17,17 @@
                 <Setter Property="FontSize" Value="14"/>
                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
                 <Setter Property="BorderThickness" Value="4" />
+
             </DataTrigger>
+            <Trigger Property="IsFocused" Value="true">
+                <Setter Property="BorderBrush" Value="Blue" />
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter Property="BorderBrush" Value="Blue" />
+            </Trigger>
+            <Trigger Property="IsKeyboardFocused" Value="true">
+                <Setter Property="BorderBrush" Value="Blue" />
+            </Trigger>
         </Style.Triggers>
     </Style>
 


### PR DESCRIPTION
Fix for #5037
### **Environment details:**

Application Name: .NET Core WPF
Microsoft .NET Core SDK Version 6.0.100-rc.1.21380.2
Windows Version: Windows10

### **Repro Steps**

1. Launch VS 2019 Int Preview
2. Tab and Navigate to Sample Applications and right click on the Editing Examiner Demo and click on build.
3..Then right click on Editing Examiner Demo then Click on Debug-->Start New Instance. 
4..Edit Examiner screen should open.
5.Tab and navigate till Immediate Window Control.
6. Tab and Navigate to "No Exception!" control below immediate Window control
7. Turn on High Contrast both High contrast black and high contrast white mode and bring the focus over the control.

### **Actual Result:**
At high contrast black and also in high contrast white, focus is not visible in "No exception! Warning Box"

### **Expected result:**
At high contrast black and also in high contrast white, focus should be visible in "No exception! Warning Box"

### **User Impact**:
Low Vision users may find difficulty in understanding where the focus currently is.