### PR TITLE
Fix A11y Issue #5044

### DIFF
--- a/Getting Started/WalkthroughFirstWPFApp/csharp/Styles.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/Styles.xaml
@@ -35,7 +35,7 @@
 
     <!-- List header style -->
     <Style x:Key="ListHeaderStyle" TargetType="{x:Type Border}">
-        <Setter Property="Height" Value="35" />
+        <Setter Property="Height" Value="Auto" />
         <Setter Property="Padding" Value="5" />
         <Setter Property="Background" Value="#3274CD" />
         <Style.Triggers>
@@ -83,7 +83,7 @@
     <!-- Button style -->
     <Style x:Key="ButtonStyle" TargetType="{x:Type Button}">
         <Setter Property="Width" Value="125" />
-        <Setter Property="Height" Value="25" />
+        <Setter Property="Height" Value="Auto" />
         <Setter Property="Margin" Value="0,10,0,0" />
         <Setter Property="HorizontalAlignment" Value="Right" />
     </Style>


### PR DESCRIPTION
### Issue
https://github.com/dotnet/wpf/issues/5044

### Repro Steps
Launch VS 2019 Int Preview
Navigate to Getting started and right click on the Expense it intro and click on build
Then right click on Expense it Intro then Click on Debug-->Start New Instance.
Check after zooming to 200%, the names title and the view button is visible as it is or not.

### Actual Result:
After zooming to 200%, the names title and the view button is getting truncated.

### Expected Result:
After zooming to 200%, the names title and view button should not get truncated.

### User Impact:
The users with low vision, not able to view the complete information.

### Description
Fixed height was set for the controls which was making the text being truncated inside the controls. Set the height to auto for the controls.