### PR TITLE
Fixing Accessibility Bug in WPF Sample

### DIFF
--- a/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
+++ b/Sample Applications/ExpenseIt/ExpenseItDemo/Styles.xaml
@@ -53,8 +53,8 @@
                                 <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
                                     <GradientBrush.GradientStops>
                                         <GradientStopCollection>
-                                            <GradientStop Color="#4E87D4" Offset="0" />
-                                            <GradientStop Color="#73B2F5" Offset="1" />
+                                            <GradientStop Color="#1056A3" Offset="0" />
+                                            <GradientStop Color="#146CCD" Offset="1" />
                                         </GradientStopCollection>
                                     </GradientBrush.GradientStops>
                                 </LinearGradientBrush>
@@ -64,8 +64,8 @@
                                 <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
                                     <GradientBrush.GradientStops>
                                         <GradientStopCollection>
-                                            <GradientStop Color="#73B2F5" Offset="0" />
-                                            <GradientStop Color="#4E87D4" Offset="1" />
+                                            <GradientStop Color="#146CCD" Offset="0" />
+                                            <GradientStop Color="#1056A3" Offset="1" />
                                         </GradientStopCollection>
                                     </GradientBrush.GradientStops>
                                 </LinearGradientBrush>
@@ -108,8 +108,8 @@
     </Style>
 
     <LinearGradientBrush x:Key="DataGridBackgroundBrush" StartPoint="0,0" EndPoint="0,1">
-        <GradientStop Color="#73B2F5" Offset="0" />
-        <GradientStop Color="#4E87D4" Offset="1" />
+        <GradientStop Color="#146CCD" Offset="0" />
+        <GradientStop Color="#1056A3" Offset="1" />
     </LinearGradientBrush>
 
     <Style x:Key="TotalDataGrid" TargetType="{x:Type DataGrid}">
@@ -134,8 +134,8 @@
                 <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
                     <GradientBrush.GradientStops>
                         <GradientStopCollection>
-                            <GradientStop Color="#4E87D4" Offset="0" />
-                            <GradientStop Color="#73B2F5" Offset="1" />
+                            <GradientStop Color="#1056A3" Offset="0" />
+                            <GradientStop Color="#146CCD" Offset="1" />
                         </GradientStopCollection>
                     </GradientBrush.GradientStops>
                 </LinearGradientBrush>
@@ -146,8 +146,8 @@
                 <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
                     <GradientBrush.GradientStops>
                         <GradientStopCollection>
-                            <GradientStop Color="#73B2F5" Offset="0" />
-                            <GradientStop Color="#4E87D4" Offset="1" />
+                            <GradientStop Color="#146CCD" Offset="0" />
+                            <GradientStop Color="#1056A3" Offset="1" />
                         </GradientStopCollection>
                     </GradientBrush.GradientStops>
                 </LinearGradientBrush>
@@ -394,6 +394,7 @@
         <Setter Property="TextTrimming" Value="WordEllipsis" />
         <Setter Property="TextWrapping" Value="WrapWithOverflow" />
         <Setter Property="Width" Value="100" />
+        <Setter Property="Foreground" Value="AntiqueWhite" />
         <Style.Triggers>
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />


### PR DESCRIPTION
Description
ExpenseItDemo: The text defined in White color Vs blue background does not have minimum ratio of 4.5:1

Repro steps: 
1.Open ExpenseItDemo from sample apps available and activate it.
2.Select any option from 'Choose Create expense repot' list and activate it.
3.Check Foreground to Background ratio of white text Vs Blue background does not have minimum colour contrast ratio 4.5:1.
4.Alternatively activate 'View Chart' button and activate it and check colour contrast ratio for white text vs blue background does not have minimum ratio 4.5:1.

Actual Result: 
Colour Contrast ratio for table header available and text at bottom 'Total expenses' is having Colour contrast ratio of 3.6:1 which is less than minimum required ratio of 4.5:1 (White text Vs Blue background)

Expected Result: 
Colour Contrast ratio for table header available and text at bottom 'Total expenses' should have Colour contrast ratio of minimum 4.5:1 or more (White text Vs Blue background)

User Impact: 
Users with Low Vision will not be able understand the text in white colour available in expense demo dialog and table header if does not have minimum Colour contrast ratio of 4.5:1. 