### PR TITLE
Fix for Accessibility Issue In Sample App

### DIFF
--- a/Sample Applications/CustomComboBox/Converters/StringToStringAndColorConverter.cs
+++ b/Sample Applications/CustomComboBox/Converters/StringToStringAndColorConverter.cs
@@ -17,7 +17,7 @@ namespace CustomComboBox.Converters
                 case "text":
                     return (value == null) ? "No movie selected!" : "Streaming.. ";
                 case "color":
-                    return (value == null) ? "Red" : "Green";
+                    return (value == null) ? "DarkRed" : "Green";
                 default:
                     return null;
             }


### PR DESCRIPTION
**Description**
'No Movie Selected' text in CutomCombobox dialog is not having minimum color contrast ratio of 4.5:1

**Repro steps**: 

Launch VS 2022 Int Preview 

Navigate to Samples applications and navigate to Getting started and select 'Customcombobox' project. 

Then right click on ‘CustomCombobox’ and then Click on Debug-->Start New Instance. 

Now in ‘Customcombobox’ window is opened.

Now check the color contrast issue for text 'No Movie Selected' text vs background and observe it is not having minimum color contrast ratio.

**Expected Result**: 
Color contrast of the text 'No Movie Selected' should have minimum required of 4.5:1 or more ratio in CustomCombobox dialog.


**User Impact**: 
Users with Low vision will face difficulty if understanding the text, if the text content is not having minimum required ratio 4.5:1.

