### PR TITLE
EditingExaminerDemo Accessibility Issue

### DIFF
--- a/Sample Applications/EditingExaminerDemo/XamlHelper.cs
+++ b/Sample Applications/EditingExaminerDemo/XamlHelper.cs
@@ -145,7 +145,7 @@ namespace EditingExaminerDemo
             // In high contrast themes, we need to ensure the syntax highlighting follows system colors.
             // Replace the normal colors here with visible ones so that we can still see the highlights.
             var BlueNormalSyntaxHighlight = (SystemParameters.HighContrast) ? SystemColors.WindowTextColor.ToString() : "Blue";
-            var RedNormalSyntaxHighlight = (SystemParameters.HighContrast) ? SystemColors.HotTrackColor.ToString() : "Red";
+            var RedNormalSyntaxHighlight = (SystemParameters.HighContrast) ? SystemColors.HotTrackColor.ToString() : "DarkRed";
 
             var front = $"<Run Foreground=\"{BlueNormalSyntaxHighlight}\">&lt;</Run>";
             var end = $"<Run Foreground=\"{BlueNormalSyntaxHighlight}\">&gt;</Run>";


### PR DESCRIPTION
**Description**
Color Contrast of text in 'red' color is less than minimum required ratio of 4.5:1

**Actual result:** 

Color contrast of the text is less than minimum required of 4.5:1 ratio. 'Page Padding' text ratio is 4.0:1, 'xlmns' text ratio is 4.0:1.

**Expected Result:** 

Color contrast ratio of the text which is in red color should meet the minimum required ratio of 4.5:1.

**User Impact:** 

Users with visual impairments will find difficulty if the text contrast ratio doesn't meet the minimum required ratio.

