### PR TITLE
AutomationPeer may be null

### DIFF
--- a/Sample Applications/DataBindingDemo/MainWindow.cs
+++ b/Sample Applications/DataBindingDemo/MainWindow.cs
@@ -52,7 +52,7 @@ namespace DataBindingDemo
         private void NotifyUpdate()
         {
             var listingPeer = ListBoxAutomationPeer.FromElement(Master);
-            listingPeer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+            listingPeer?.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
         }
 
         private void RemoveGrouping(object sender, RoutedEventArgs args)


### PR DESCRIPTION
Caused failure when clicked Group Check (e.g. Group by category).