### PR TITLE
Fix for : WPF_ListofProducts_AddProductListing_Zoom: The "Add Product" Button is not visible at 200% zoom.

### DIFF
--- a/Sample Applications/DataBindingDemo/MainWindow.xaml
+++ b/Sample Applications/DataBindingDemo/MainWindow.xaml
@@ -20,7 +20,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="300" />
+            <RowDefinition Height="200" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>


### PR DESCRIPTION
GitHubTags:#A11yMAS;#A11yTCS;#.NET Core[WPF]-Win32-June2022;#.NET Core;#A11ySev2;#WCAG1.4.4;#DesktopApp;#Win11;#Zoom;#Benchmark;

Issue No : https://github.com/dotnet/wpf/issues/6734

Environment Details:
.NET Core
WPF
Operating System: Windows 11 Enterprise 21H2

Steps to Reproduce:
Launch VS 2019 Int Preview
Navigate to Sample Applications and right-click on the DatabindingDemo and click on build.
Then right click on DatabindingDemo then Click on Debug-->Start New Instance.
List of products screen should open.
5.Navigate to Add product button and click on it.
Zoom the screen to 200% and observe that The "Add Product" Button is not visible at 200% zoom
Actual:
The "Add Product" Button is not visible at 200% zoom.

Expected:
The "Add Product" Button should be visible at 200% zoom.

User Impact:
Low vision users won't be able to see the add product button.