### PR TITLE
Fix : [ Data Binding Demo ] Screen reader is unnecessarily announcing list items for sale after checking / unchecking the checkbox.

### DIFF
--- a/Sample Applications/DataBindingDemo/MainWindow.cs
+++ b/Sample Applications/DataBindingDemo/MainWindow.cs
@@ -44,9 +44,6 @@ namespace DataBindingDemo
             // This groups the items in the view by the property "Category"
             var groupDescription = new PropertyGroupDescription {PropertyName = "Category"};
             _listingDataView.GroupDescriptions.Add(groupDescription);
-
-            NotifyUpdate();
-
         }
 
         private void NotifyUpdate()
@@ -58,7 +55,6 @@ namespace DataBindingDemo
         private void RemoveGrouping(object sender, RoutedEventArgs args)
         {
             _listingDataView.GroupDescriptions.Clear();
-            NotifyUpdate();
         }
 
         private void AddSorting(object sender, RoutedEventArgs args)
@@ -70,25 +66,21 @@ namespace DataBindingDemo
                 new SortDescription("Category", ListSortDirection.Ascending));
             _listingDataView.SortDescriptions.Add(
                 new SortDescription("StartDate", ListSortDirection.Ascending));
-            NotifyUpdate();
         }
 
         private void RemoveSorting(object sender, RoutedEventArgs args)
         {
             _listingDataView.SortDescriptions.Clear();
-            NotifyUpdate();
         }
 
         private void AddFiltering(object sender, RoutedEventArgs args)
         {
             _listingDataView.Filter += ShowOnlyBargainsFilter;
-            NotifyUpdate();
         }
 
         private void RemoveFiltering(object sender, RoutedEventArgs args)
         {
             _listingDataView.Filter -= ShowOnlyBargainsFilter;
-            NotifyUpdate();
         }
     }
 


### PR DESCRIPTION
#### Fixes Issue : [wpf/6733](https://github.com/dotnet/wpf/issues/6733)

### Actual:
Screen reader is unnecessarily announcing list items for sale after checking / unchecking the checkbox.

**This issue is also observed with the screen reader Narrator.**

**_This issue is observed with all the checkboxes present o this screen._**

### Expected:
Screen reader should not  unnecessarily announce list items for sale after checking / unchecking the checkbox. It should announce the results.


“[Check out Accessibility Insights!](https://accessibilityinsights.io/) - Identify accessibility bugs before check-in and make bug fixing faster and easier.”

**GitHubTags**:#A11yMAS;##A11yTCS;#.NET Core[WPF]-Win32-June2022;#.NET Core;#A11ySev2;#WCAG1.3.1;#Element:Checkbox;#NVDA;#Narrator;#DesktopApp;#Win11;#ColorContrast;#Benchmark;

### Environment Details:
.NET Core
WPF
Operating System: Windows 11 Enterprise 21H2

### Steps to Reproduce:

1. Launch VS 2019 Int Preview
2. Navigate to Sample Applications and right click on the DatabindingDemo and click on build.
3. Then right click on DatabindingDemo then Click on Debug-->Start New Instance. 
4. List of products screen should open.
5. Select Group by category check box.
6. Turn on the screen reader and observe the announcement.

### User Impact:
Screenreader Users will receive incorrect indications because of unnecessary content announcements.