### PR TITLE
Fixed issue :: A11y_.NET Core_WPF_ExpenseItIntro_ViewExpenseReport_Co…

### DIFF
--- a/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseItHome.xaml
+++ b/Getting Started/WalkthroughFirstWPFApp/csharp/ExpenseItHome.xaml
@@ -68,7 +68,7 @@
         </Label>
 
         <Border Grid.Column="1" Grid.Row="1" Style="{StaticResource ListHeaderStyle}">
-            <Label Style="{StaticResource ListHeaderTextStyle}">Names</Label>
+            <Label FontWeight="ExtraBold" Style="{StaticResource ListHeaderTextStyle}">Names</Label>
         </Border>
 
         <ListBox Name="peopleListBox" 


### PR DESCRIPTION
Fixes [#6736](https://github.com/dotnet/wpf/issues/6736)


Description
A11y_.NET Core_WPF_ExpenseItIntro_ViewExpenseReport_Contrast: The color contrast for "Names" list item is less than 4.5:1.

Customer Impact
Low vision users won't be able to see the list item.

Regression
NO

Risk
Low. 