### PR TITLE
Fix User can Add Product without Item description.

### DIFF
--- a/Sample Applications/DataBindingDemo/AddProductWindow.cs
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.cs
@@ -19,7 +19,7 @@ namespace DataBindingDemo
         {
             InitializeComponent();
         }
-
+       
         private void OnInit(object sender, RoutedEventArgs e)
         {
             DataContext = new AuctionItem("Type your description here",
@@ -42,9 +42,17 @@ namespace DataBindingDemo
         {
             var automationPeer = UIElementAutomationPeer.CreatePeerForElement(ErrorTextBlock);
 
-            if(StartDateEntryForm.Text.Length == 0 || StartPriceEntryForm.Text.Length == 0)
+            if(StartDateEntryForm.Text.Length == 0 )
             {
-                AnnounceError("Please, fill both date and start price");
+                AnnounceError("Please, fill start date");
+            }
+            else if(StartPriceEntryForm.Text.Length == 0)
+            {
+                AnnounceError("Please, fill start price");
+            }
+            else if(DescriptionEntryForm.Text.Length == 0)
+            {
+                AnnounceError("Please, fill item description");
             }
             else if (Validation.GetHasError(StartDateEntryForm))
             {

--- a/Sample Applications/DataBindingDemo/AddProductWindow.xaml
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.xaml
@@ -50,11 +50,22 @@
 
                     <TextBlock Grid.Row="1" Grid.Column="0"
                                Style="{StaticResource SmallTitleStyle}" Margin="0,5,0,5">
-                        Item Description:
+                        Item Description: *
                     </TextBlock>
                     <TextBox Name="DescriptionEntryForm" AutomationProperties.Name="Item Description" Grid.Row="1" Grid.Column="1"
-                             Text="{Binding Path=Description, UpdateSourceTrigger=PropertyChanged}"
-                             Style="{StaticResource TextStyleTextBox}" Margin="8,5,0,5" />
+                             AutomationProperties.IsRequiredForForm="True"
+                             Style="{StaticResource TextStyleTextBox}" Margin="8,5,0,5" 
+                             Validation.Error="OnValidationError" >
+                        <TextBox.Text>
+                            
+                            <Binding Path="Description" UpdateSourceTrigger="PropertyChanged"
+                                     NotifyOnValidationError="True" >
+                                <Binding.ValidationRules>
+                                    <ExceptionValidationRule />
+                                </Binding.ValidationRules>
+                            </Binding>
+                        </TextBox.Text>
+                    </TextBox>
 
                     <TextBlock Grid.Row="2" Grid.Column="0" Style="{StaticResource SmallTitleStyle}" Margin="0,5,0,5">Start Price: *</TextBlock>
 

--- a/Sample Applications/DataBindingDemo/AuctionItem.cs
+++ b/Sample Applications/DataBindingDemo/AuctionItem.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
 
 namespace DataBindingDemo
 {
@@ -52,8 +53,14 @@ namespace DataBindingDemo
             get { return _description; }
             set
             {
+                
+                if (string.IsNullOrEmpty(value))
+                {
+                    throw new ArgumentException("Item description should be added");
+                }
                 _description = value;
                 OnPropertyChanged("Description");
+
             }
         }
 


### PR DESCRIPTION
## Issue: #439
## Actual Result: 

Users can Add product without typing Item Description.

 

## Expected Result: 

User should not be able to Add products without item Description. Item description should be ‘Required field’ just like ‘start date’ and ‘start price’.