### PR TITLE
Fix Users can edit the placeholder text ‘Type your description here’

### DIFF
--- a/Sample Applications/DataBindingDemo/AddProductWindow.cs
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.cs
@@ -22,7 +22,7 @@ namespace DataBindingDemo
        
         private void OnInit(object sender, RoutedEventArgs e)
         {
-            DataContext = new AuctionItem("Type your description here",
+            DataContext = new AuctionItem(null,
                 ProductCategory.DvDs, 1, DateTime.Now, ((App) Application.Current).CurrentUser,
                 SpecialFeatures.None);
         }

--- a/Sample Applications/DataBindingDemo/AddProductWindow.cs
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.cs
@@ -19,7 +19,7 @@ namespace DataBindingDemo
         {
             InitializeComponent();
         }
-
+       
         private void OnInit(object sender, RoutedEventArgs e)
         {
             DataContext = new AuctionItem("Type your description here",
@@ -42,9 +42,17 @@ namespace DataBindingDemo
         {
             var automationPeer = UIElementAutomationPeer.CreatePeerForElement(ErrorTextBlock);
 
-            if(StartDateEntryForm.Text.Length == 0 || StartPriceEntryForm.Text.Length == 0)
+            if(StartDateEntryForm.Text.Length == 0 )
             {
-                AnnounceError("Please, fill both date and start price");
+                AnnounceError("Please, fill start date");
+            }
+            else if(StartPriceEntryForm.Text.Length == 0)
+            {
+                AnnounceError("Please, fill start price");
+            }
+            else if(DescriptionEntryForm.Text.Length == 0)
+            {
+                AnnounceError("Please, fill Item Discription");
             }
             else if (Validation.GetHasError(StartDateEntryForm))
             {

--- a/Sample Applications/DataBindingDemo/AddProductWindow.xaml
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.xaml
@@ -50,11 +50,22 @@
 
                     <TextBlock Grid.Row="1" Grid.Column="0"
                                Style="{StaticResource SmallTitleStyle}" Margin="0,5,0,5">
-                        Item Description:
+                        Item Description: *
                     </TextBlock>
                     <TextBox Name="DescriptionEntryForm" AutomationProperties.Name="Item Description" Grid.Row="1" Grid.Column="1"
-                             Text="{Binding Path=Description, UpdateSourceTrigger=PropertyChanged}"
-                             Style="{StaticResource TextStyleTextBox}" Margin="8,5,0,5" />
+                             AutomationProperties.IsRequiredForForm="True"
+                             Style="{StaticResource TextStyleTextBox}" Margin="8,5,0,5" 
+                             Validation.Error="OnValidationError" >
+                        <TextBox.Text>
+                            
+                            <Binding Path="Description" UpdateSourceTrigger="PropertyChanged"
+                                     NotifyOnValidationError="True" >
+                                <Binding.ValidationRules>
+                                    <ExceptionValidationRule />
+                                </Binding.ValidationRules>
+                            </Binding>
+                        </TextBox.Text>
+                    </TextBox>
 
                     <TextBlock Grid.Row="2" Grid.Column="0" Style="{StaticResource SmallTitleStyle}" Margin="0,5,0,5">Start Price: *</TextBlock>
 

--- a/Sample Applications/DataBindingDemo/AddProductWindow.xaml
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.xaml
@@ -61,6 +61,9 @@
                                 <Binding ElementName="DescriptionEntryForm" Path="IsFocused"/>
                             </MultiBinding>
                         </TextBlock.Visibility>
+                        <TextBlock.Foreground>
+                            <SolidColorBrush Opacity="0.5" Color="Black"/>
+                        </TextBlock.Foreground>
                     </TextBlock>
                     <TextBox Name="DescriptionEntryForm" AutomationProperties.Name="Item Description" Grid.Row="1" Grid.Column="1"
                              AutomationProperties.IsRequiredForForm="True"

--- a/Sample Applications/DataBindingDemo/AddProductWindow.xaml
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.xaml
@@ -7,13 +7,14 @@
         mc:Ignorable="d"
         Title="Add Product Listing" SizeToContent="WidthAndHeight" Loaded="OnInit">
     <Window.Resources>
-            <local:SpecialFeaturesConverter x:Key="SpecialFeaturesConverter" />
-            <ControlTemplate x:Key="ValidationTemplate">
-                <DockPanel>
-                    <TextBlock Foreground="Red" FontSize="20">!</TextBlock>
-                    <AdornedElementPlaceholder />
-                </DockPanel>
-            </ControlTemplate>
+        <local:SpecialFeaturesConverter x:Key="SpecialFeaturesConverter" />
+        <local:BooltoVisibilityConvertor x:Key="InputToVisibility" />
+        <ControlTemplate x:Key="ValidationTemplate">
+            <DockPanel>
+                <TextBlock Foreground="Red" FontSize="20">!</TextBlock>
+                <AdornedElementPlaceholder />
+            </DockPanel>
+        </ControlTemplate>
     </Window.Resources>
 
     <Border Padding="20">
@@ -52,12 +53,22 @@
                                Style="{StaticResource SmallTitleStyle}" Margin="0,5,0,5">
                         Item Description: *
                     </TextBlock>
+
+                    <TextBlock Text="Type Item Description" Margin="10,5,5,6" Grid.Column="1" Grid.Row="1">
+                        <TextBlock.Visibility>
+                            <MultiBinding Converter="{StaticResource InputToVisibility}">
+                                <Binding ElementName="DescriptionEntryForm" Path="Text.IsEmpty" />
+                                <Binding ElementName="DescriptionEntryForm" Path="IsFocused"/>
+                            </MultiBinding>
+                        </TextBlock.Visibility>
+                    </TextBlock>
                     <TextBox Name="DescriptionEntryForm" AutomationProperties.Name="Item Description" Grid.Row="1" Grid.Column="1"
                              AutomationProperties.IsRequiredForForm="True"
                              Style="{StaticResource TextStyleTextBox}" Margin="8,5,0,5" 
-                             Validation.Error="OnValidationError" >
+                             Validation.Error="OnValidationError"
+                             Background="Transparent">
                         <TextBox.Text>
-                            
+
                             <Binding Path="Description" UpdateSourceTrigger="PropertyChanged"
                                      NotifyOnValidationError="True" >
                                 <Binding.ValidationRules>
@@ -66,7 +77,8 @@
                             </Binding>
                         </TextBox.Text>
                     </TextBox>
-
+                    
+                    
                     <TextBlock Grid.Row="2" Grid.Column="0" Style="{StaticResource SmallTitleStyle}" Margin="0,5,0,5">Start Price: *</TextBlock>
 
                     <TextBox Name="StartPriceEntryForm" AutomationProperties.Name="Start Price" Grid.Row="2" Grid.Column="1"

--- a/Sample Applications/DataBindingDemo/AuctionItem.cs
+++ b/Sample Applications/DataBindingDemo/AuctionItem.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
 
 namespace DataBindingDemo
 {
@@ -52,8 +53,14 @@ namespace DataBindingDemo
             get { return _description; }
             set
             {
+                
+                if (string.IsNullOrEmpty(value))
+                {
+                    throw new ArgumentException("Item Description Should be added");
+                }
                 _description = value;
                 OnPropertyChanged("Description");
+
             }
         }
 

--- a/Sample Applications/DataBindingDemo/BooltoVisibilityConvertor.cs
+++ b/Sample Applications/DataBindingDemo/BooltoVisibilityConvertor.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+
+namespace DataBindingDemo
+{
+
+    public class BooltoVisibilityConvertor : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            bool hasText = !(bool)values[0];
+            bool hasFocus = (bool)values[1];
+            
+            if (hasText || hasFocus)
+            {
+                return Visibility.Collapsed;
+            }
+            return Visibility.Visible;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
## Issue: #441
## Actual Result:
Users can edit the placeholder text ‘Type your description here’.

## Expected Result:
Upon Navigating to item description edit box, text ‘Type your description here’ should not be editable. 'Type your description here' should be a placeholder text.

Note: When Screen reader focus is on item description edit box, Narrator announces as 'Type your description here'. Screen reader user will know that it is placeholder text and may start typing the item description without knowing that 'Type your description here' is editable.