### PR TITLE
Fix Text under help tab is not visible in high contrast Aquatic theme

### DIFF
--- a/Sample Applications/EditingExaminerDemo/MainWindow.xaml
+++ b/Sample Applications/EditingExaminerDemo/MainWindow.xaml
@@ -28,7 +28,7 @@
                             <FlowDocument
                                 ColumnWidth="400" AutomationProperties.Name="Help Text"
                                 IsOptimalParagraphEnabled="True" IsHyphenationEnabled="True">
-                                <Section FontSize="12">
+                                <Section FontSize="12" Style="{StaticResource HelpSectionTextHighContrastStyle}">
                                     <Paragraph FontSize="22" FontWeight="Bold" AutomationProperties.HeadingLevel="Level1">Introducing Editing Examiner</Paragraph>
 
                                     <Paragraph>


### PR DESCRIPTION
## Actual Result: 

In High Contrast aquatic theme the help text present under help tab is not completely visible. In hc 'Desert' text is clearly visible.
 

## Expected Result: 

In High Contrast Aquatic theme the help text should be visible .
 

## User Impact: 

Low Vision users will not be able to read the help text.

 
MAS Link: [MAS 4.3.1 – No Disruption of Accessibility Features](https://aka.ms/MAS4.3.1)