### PR TITLE
[Net4.8 ]Fixing Inappropriate announcement of 'Special feature' for p…

### DIFF
--- a/Sample Applications/DataBindingDemo/Styles.xaml
+++ b/Sample Applications/DataBindingDemo/Styles.xaml
@@ -128,7 +128,7 @@
     <Style x:Key="AuctionItemContainerStyle">
         <Setter Property="AutomationProperties.Name">
             <Setter.Value>
-                <MultiBinding StringFormat="{} Color: {0}, Description: {1}, Current price: ${2}">
+                <MultiBinding StringFormat="{} Special Feature: {0}, Description: {1}, Current price: ${2}">
                     <Binding Path="SpecialFeatures" />
                     <Binding Path="Description" />
                     <Binding Path="CurrentPrice" />


### PR DESCRIPTION
Issue: https://github.com/microsoft/WPF-Samples/issues/437
Actual Result:
Inappropriate announcement by Narrator for the special feature:

if the Special feature is selected as 'none', Narrator announces as "Color: none"

if the Special feature is selected as 'highlight', Narrator announces as "Color: highlight"

if the Special feature is selected as 'color', Narrator announces as "Color: color"

Expected Result:
if the Special feature is selected as 'none', Narrator should announce as:

"Special feature: none"

Similarly, for Special feature: highlight and special feature: color.

User Impact:
Users with no vision who rely on screen readers will not be able to understand the special feature of the particular product and can be get confused with narrator announcement.