### PR TITLE
[Net48-sdk] Fix text contrast in CustomComboBox

### DIFF
--- a/Sample Applications/CustomComboBox/Converters/StringToStringAndColorConverter.cs
+++ b/Sample Applications/CustomComboBox/Converters/StringToStringAndColorConverter.cs
@@ -17,7 +17,7 @@ namespace CustomComboBox.Converters
                 case "text":
                     return (value == null) ? "No movie selected!" : "Streaming.. ";
                 case "color":
-                    return (value == null) ? "Red" : "Green";
+                    return (value == null) ? "FireBrick" : "Green";
                 default:
                     return null;
             }


### PR DESCRIPTION
Branch: Net48-sdk
The color contrast ratio for the 'No movies selected' text in in custom combo box is 3.99 which is <=4.5:1. #456