### PR TITLE
Fix highlighted border contrast

### DIFF
--- a/Sample Applications/DataBindingDemo/App.xaml
+++ b/Sample Applications/DataBindingDemo/App.xaml
@@ -71,7 +71,7 @@
                         <DataTrigger.Value>
                             <local:SpecialFeatures>Highlight</local:SpecialFeatures>
                         </DataTrigger.Value>
-                        <Setter Property="BorderBrush" Value="#C67E0A" TargetName="border" />
+                        <Setter Property="BorderBrush" Value="OrangeRed" TargetName="border" />
                         <Setter Property="Foreground" Value="Navy" TargetName="descriptionTitle" />
                         <Setter Property="Foreground" Value="Navy" TargetName="currentPriceTitle" />
                         <Setter Property="Visibility" Value="Visible" TargetName="star" />

--- a/Sample Applications/DataBindingDemo/App.xaml
+++ b/Sample Applications/DataBindingDemo/App.xaml
@@ -71,7 +71,7 @@
                         <DataTrigger.Value>
                             <local:SpecialFeatures>Highlight</local:SpecialFeatures>
                         </DataTrigger.Value>
-                        <Setter Property="BorderBrush" Value="Orange" TargetName="border" />
+                        <Setter Property="BorderBrush" Value="#C67E0A" TargetName="border" />
                         <Setter Property="Foreground" Value="Navy" TargetName="descriptionTitle" />
                         <Setter Property="Foreground" Value="Navy" TargetName="currentPriceTitle" />
                         <Setter Property="Visibility" Value="Visible" TargetName="star" />


### PR DESCRIPTION
The non-text contrast ratio of 'items with border outline of highlighted' is less than minimum required ratio. #465