### PR TITLE
[Net481-sdk] Fix Red color text contrast

### DIFF
--- a/Sample Applications/EditingExaminerDemo/XamlHelper.cs
+++ b/Sample Applications/EditingExaminerDemo/XamlHelper.cs
@@ -145,7 +145,7 @@ namespace EditingExaminerDemo
             // In high contrast themes, we need to ensure the syntax highlighting follows system colors.
             // Replace the normal colors here with visible ones so that we can still see the highlights.
             var BlueNormalSyntaxHighlight = (SystemParameters.HighContrast) ? SystemColors.WindowTextColor.ToString() : "Blue";
-            var RedNormalSyntaxHighlight = (SystemParameters.HighContrast) ? SystemColors.HotTrackColor.ToString() : "Red";
+            var RedNormalSyntaxHighlight = (SystemParameters.HighContrast) ? SystemColors.HotTrackColor.ToString() : "DarkRed";
 
             var front = $"<Run Foreground=\"{BlueNormalSyntaxHighlight}\">&lt;</Run>";
             var end = $"<Run Foreground=\"{BlueNormalSyntaxHighlight}\">&gt;</Run>";


### PR DESCRIPTION
[ Editing Examiner Demo]: The color contrast ratio for the text present in red color under “Core XML” is 4.0:1 which is less than 4.5:1 #473