### PR TITLE
Fixing help tab in high contrast theme

### DIFF
--- a/Sample Applications/EditingExaminerDemo/MainWindow.xaml
+++ b/Sample Applications/EditingExaminerDemo/MainWindow.xaml
@@ -28,7 +28,7 @@
                             <FlowDocument
                                 ColumnWidth="400" AutomationProperties.Name="Help Text"
                                 IsOptimalParagraphEnabled="True" IsHyphenationEnabled="True">
-                                <Section FontSize="12">
+                                <Section FontSize="12" Style="{StaticResource HelpSectionTextHighContrastStyle}">
 
 									<!-- Removing AutomationLevel.HeadingLevel as it is not present for .NET Fx 4.8 -->
                                     <!--<Paragraph FontSize="22" FontWeight="Bold" AutomationProperties.HeadingLevel="Level1">Introducing Editing Examiner</Paragraph>-->


### PR DESCRIPTION
The information present under “Help” tab is not clearly visible in high contrast (Aquatic) mode. https://github.com/microsoft/WPF-Samples/issues/460