### PR TITLE
[Net48-sdk] Fix color contrast ratio of Tab separator

### DIFF
--- a/Sample Applications/EditingExaminerDemo/App.xaml
+++ b/Sample Applications/EditingExaminerDemo/App.xaml
@@ -7,6 +7,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/EditingExaminerDemo;component/Styles.xaml" />
+                <ResourceDictionary Source="/EditingExaminerDemo;component/TabItem.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/Sample Applications/EditingExaminerDemo/MainWindow.xaml
+++ b/Sample Applications/EditingExaminerDemo/MainWindow.xaml
@@ -10,19 +10,22 @@
     MinHeight="600"
     MinWidth="750"
     SizeChanged="window_SizeChanged">
+    <Window.Resources>
+        <SolidColorBrush x:Key="TabBorderColor">#666464</SolidColorBrush>
+    </Window.Resources>
     <StackPanel Name="TopPanel" Width="800" Height="600">
         <StackPanel Name="Panel1" Orientation="Vertical">
-            <TabControl Name="MainTab" SelectionChanged="UpdateDisplayTabs">
-                <TabItem Name="RichTab" Header="RichTextBox"
+            <TabControl Name="MainTab" SelectionChanged="UpdateDisplayTabs" BorderBrush="{StaticResource TabBorderColor}">
+                <TabItem Name="RichTab" Header="RichTextBox" Template="{DynamicResource TabItemTemplate}" BorderBrush="{StaticResource TabBorderColor}"
                          AutomationProperties.HelpText="Make edits in this RichTextBox. As you edit, you can see what your edits look like in real time in the tabs below.">
                     <RichTextBox Name="MainEditor" AutomationProperties.Name="Rich Text" TextChanged="UpdateDisplayTabs" AcceptsTab="True" Height="250"
                                  Style="{StaticResource TextBoxBorderContrastStyle}"
                                  Width="800" VerticalScrollBarVisibility="Visible" BorderBrush="Black" />
                 </TabItem>
-                <TabItem Name="PanelTab" AutomationProperties.Name="Panel" Header="Panel" AutomationProperties.HelpText="Panel Tab">
+                <TabItem Name="PanelTab" AutomationProperties.Name="Panel" Header="Panel" AutomationProperties.HelpText="Panel Tab" Template="{DynamicResource TabItemTemplate}" BorderBrush="{StaticResource TabBorderColor}">
                     <StackPanel />
                 </TabItem>
-                <TabItem Header="Help" AutomationProperties.Name="Help" AutomationProperties.HelpText="Help Tab: The content in this tab explains how to use the demo.">
+                <TabItem Header="Help" AutomationProperties.Name="Help" AutomationProperties.HelpText="Help Tab: The content in this tab explains how to use the demo." Template="{DynamicResource TabItemTemplate}" BorderBrush="{StaticResource TabBorderColor}">
                     <Border BorderThickness="1" BorderBrush="Black">
                         <FlowDocumentScrollViewer Margin="1">
                             <FlowDocument
@@ -163,12 +166,12 @@ Selection = RichTextBox.Selection;
         </StackPanel>
         <StackPanel Name="Panel2" Orientation="Horizontal">
             <TabControl SelectionChanged="UpdateDisplayTabs" Name="TabControl" HorizontalContentAlignment="Left"
-                        Width="400" Height="250">
-                <TabItem Header="DocumentTree" 
+                        Width="400" Height="250" BorderBrush="{StaticResource TabBorderColor}">
+                <TabItem Header="DocumentTree" Template="{DynamicResource TabItemTemplate}" BorderBrush="{StaticResource TabBorderColor}"
                          AutomationProperties.HelpText="The DocumentTree Tab displays the entire TreeView of the document container. It demonstrates how to use the TextElementCollection features. It updates automatically on each TextChanged event of the RichTextBox. This allows you to visualize the document hierarchy.">
                     <TreeView Name="TextTreeView" AutomationProperties.Name="Document Elements"/>
                 </TabItem>
-                <TabItem Header="SelectionXaml" Name="TabSelectionXaml" 
+                <TabItem Header="SelectionXaml" Name="TabSelectionXaml" Template="{DynamicResource TabItemTemplate}" BorderBrush="{StaticResource TabBorderColor}"
                          AutomationProperties.HelpText="This tab displays the underlying XAML of the selected content within the RichTextBox.">
                     <TextBox Name="SelectionXaml" VerticalScrollBarVisibility="Visible" AutomationProperties.Name="Selection Xaml"
                              AutomationProperties.HelpText="Displays underlying XAML of selected content of RichTextBox.">
@@ -182,7 +185,7 @@ Selection = RichTextBox.Selection;
                         </TextBox.ContextMenu>
                     </TextBox>
                 </TabItem>
-                <TabItem Header="TextSerializedXaml" Name="TabTextSerializedXaml" 
+                <TabItem Header="TextSerializedXaml" Name="TabTextSerializedXaml" Template="{DynamicResource TabItemTemplate}" BorderBrush="{StaticResource TabBorderColor}"
                          AutomationProperties.HelpText="By clicking on the Text Serialization tab, the underlying XAML is exposed, using WPF serialization features. The TreeView is instantly updated when the Tab is selected. You can edit your XAML content and set it back to the RichTextBox by right clicking and selecting the correct item.">
                     <TextBox Name="TextSerializedXaml" AutomationProperties.Name="Text Serialized Xaml" VerticalScrollBarVisibility="Visible"
                              AutomationProperties.HelpText="Displays underlying XAML of RichTextBox.">
@@ -196,7 +199,7 @@ Selection = RichTextBox.Selection;
                         </TextBox.ContextMenu>
                     </TextBox>
                 </TabItem>
-                <TabItem Header="CoreXaml" Name="TabCoreXaml" 
+                <TabItem Header="CoreXaml" Name="TabCoreXaml" Template="{DynamicResource TabItemTemplate}" BorderBrush="{StaticResource TabBorderColor}"
                          AutomationProperties.HelpText="This tab accesses the WPF core parser in order to parse an object. The object can then be inserted back into the RichTextBox. Alternately you can use this view to see how the RichTextBox content is serialized back to XAML.">
                     <RichTextBox Name="CoreXaml" AutomationProperties.Name="Core Xaml" VerticalScrollBarVisibility="Visible" Style="{StaticResource XamlSyntaxHighlighterStyle}">
                         <RichTextBox.ContextMenu>

--- a/Sample Applications/EditingExaminerDemo/TabItem.xaml
+++ b/Sample Applications/EditingExaminerDemo/TabItem.xaml
@@ -1,0 +1,185 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    
+    <LinearGradientBrush x:Key="TabItem.MouseOver.Background" EndPoint="0,1" StartPoint="0,0">
+        <GradientStop Color="#ECF4FC" Offset="0.0"/>
+        <GradientStop Color="#DCECFC" Offset="1.0"/>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="TabItem.MouseOver.Border" Color="#7EB4EA"/>
+    <SolidColorBrush x:Key="TabItem.Selected.Background" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="TabItem.Selected.Border" Color="#666464"/>
+    <SolidColorBrush x:Key="TabItem.Disabled.Background" Color="#F0F0F0"/>
+    <SolidColorBrush x:Key="TabItem.Disabled.Border" Color="#666464"/>
+
+    <ControlTemplate x:Key="TabItemTemplate" TargetType="{x:Type TabItem}">
+        <Grid x:Name="templateRoot" SnapsToDevicePixels="true">
+            <Border x:Name="mainBorder" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,1,1,0" Margin="0">
+                <Border x:Name="innerBorder" Background="{StaticResource TabItem.Selected.Background}" BorderBrush="{StaticResource TabItem.Selected.Border}" BorderThickness="1,1,1,0" Margin="-1" Opacity="0"/>
+            </Border>
+            <ContentPresenter x:Name="contentPresenter" ContentSource="Header" Focusable="False" HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+        </Grid>
+        <ControlTemplate.Triggers>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Left"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Background" TargetName="mainBorder" Value="{StaticResource TabItem.MouseOver.Background}"/>
+                <Setter Property="BorderBrush" TargetName="mainBorder" Value="{StaticResource TabItem.MouseOver.Border}"/>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="1,1,0,1"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="1,1,0,1"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Background" TargetName="mainBorder" Value="{StaticResource TabItem.MouseOver.Background}"/>
+                <Setter Property="BorderBrush" TargetName="mainBorder" Value="{StaticResource TabItem.MouseOver.Border}"/>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="1,0,1,1"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="1,0,1,1"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Background" TargetName="mainBorder" Value="{StaticResource TabItem.MouseOver.Background}"/>
+                <Setter Property="BorderBrush" TargetName="mainBorder" Value="{StaticResource TabItem.MouseOver.Border}"/>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="0,1,1,1"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="0,1,1,1"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Top"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Background" TargetName="mainBorder" Value="{StaticResource TabItem.MouseOver.Background}"/>
+                <Setter Property="BorderBrush" TargetName="mainBorder" Value="{StaticResource TabItem.MouseOver.Border}"/>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="1,1,1,0"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="1,1,1,0"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsEnabled, RelativeSource={RelativeSource Self}}" Value="false"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Left"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Opacity" TargetName="contentPresenter" Value="0.56"/>
+                <Setter Property="Background" TargetName="mainBorder" Value="{StaticResource TabItem.Disabled.Background}"/>
+                <Setter Property="BorderBrush" TargetName="mainBorder" Value="{StaticResource TabItem.Disabled.Border}"/>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="1,1,0,1"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="1,1,0,1"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsEnabled, RelativeSource={RelativeSource Self}}" Value="false"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Opacity" TargetName="contentPresenter" Value="0.56"/>
+                <Setter Property="Background" TargetName="mainBorder" Value="{StaticResource TabItem.Disabled.Background}"/>
+                <Setter Property="BorderBrush" TargetName="mainBorder" Value="{StaticResource TabItem.Disabled.Border}"/>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="1,0,1,1"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="1,0,1,1"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsEnabled, RelativeSource={RelativeSource Self}}" Value="false"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Opacity" TargetName="contentPresenter" Value="0.56"/>
+                <Setter Property="Background" TargetName="mainBorder" Value="{StaticResource TabItem.Disabled.Background}"/>
+                <Setter Property="BorderBrush" TargetName="mainBorder" Value="{StaticResource TabItem.Disabled.Border}"/>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="0,1,1,1"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="0,1,1,1"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsEnabled, RelativeSource={RelativeSource Self}}" Value="false"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Top"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Opacity" TargetName="contentPresenter" Value="0.56"/>
+                <Setter Property="Background" TargetName="mainBorder" Value="{StaticResource TabItem.Disabled.Background}"/>
+                <Setter Property="BorderBrush" TargetName="mainBorder" Value="{StaticResource TabItem.Disabled.Border}"/>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="1,1,1,0"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="1,1,1,0"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="false"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Left"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="1,1,0,1"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="1,1,0,1"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Left"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Panel.ZIndex" Value="1"/>
+                <Setter Property="Margin" Value="-2,-2,0,-2"/>
+                <Setter Property="Opacity" TargetName="innerBorder" Value="1"/>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="1,1,0,1"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="1,1,0,1"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="false"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="1,0,1,1"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="1,0,1,1"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Panel.ZIndex" Value="1"/>
+                <Setter Property="Margin" Value="-2,0,-2,-2"/>
+                <Setter Property="Opacity" TargetName="innerBorder" Value="1"/>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="1,0,1,1"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="1,0,1,1"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="false"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="0,1,1,1"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="0,1,1,1"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Panel.ZIndex" Value="1"/>
+                <Setter Property="Margin" Value="0,-2,-2,-2"/>
+                <Setter Property="Opacity" TargetName="innerBorder" Value="1"/>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="0,1,1,1"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="0,1,1,1"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="false"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Top"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="1,1,1,0"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="1,1,1,0"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Top"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Panel.ZIndex" Value="1"/>
+                <Setter Property="Margin" Value="-2,-2,-2,0"/>
+                <Setter Property="Opacity" TargetName="innerBorder" Value="1"/>
+                <Setter Property="BorderThickness" TargetName="innerBorder" Value="1,1,1,0"/>
+                <Setter Property="BorderThickness" TargetName="mainBorder" Value="1,1,1,0"/>
+            </MultiDataTrigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+    
+</ResourceDictionary>


### PR DESCRIPTION
Editing Examiner Demo]: The color contrast ratio for 'Rich edit text' tab and 'Panel' tab separator and 'Document tree' tab and 'selection XML' tab separator is 1.818:1 which is <=3:1. https://github.com/microsoft/WPF-Samples/issues/463