### PR TITLE
Fix Non-text color contrast between keyboard focus and its background.

### DIFF
--- a/Sample Applications/DataBindingDemo/App.xaml
+++ b/Sample Applications/DataBindingDemo/App.xaml
@@ -22,9 +22,9 @@
                             <RowDefinition />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="20" />
-                            <ColumnDefinition Width="86" />
-                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
                         <Polygon Grid.Row="0" Grid.Column="0" Grid.RowSpan="4"
@@ -110,7 +110,7 @@
                         <RowDefinition />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="113" />
+                        <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 

--- a/Sample Applications/DataBindingDemo/MainWindow.xaml
+++ b/Sample Applications/DataBindingDemo/MainWindow.xaml
@@ -55,17 +55,17 @@
 
         
         <ListBox Name="Master" AutomationProperties.Name="Items For Sale" Grid.Row="2" Grid.ColumnSpan="3" Margin="8"
-            ItemsSource="{Binding Source={StaticResource ListingDataView}}"
-            ItemContainerStyle="{StaticResource AuctionItemContainerStyle}"
-            AutomationProperties.LiveSetting="Assertive">
+                ItemsSource="{Binding Source={StaticResource ListingDataView}}"
+                ItemContainerStyle="{StaticResource AuctionItemContainerStyle}"
+                AutomationProperties.LiveSetting="Assertive">
             <ListBox.GroupStyle>
                 <GroupStyle
-            HeaderTemplate="{StaticResource GroupingHeaderTemplate}" />
+                HeaderTemplate="{StaticResource GroupingHeaderTemplate}" />
             </ListBox.GroupStyle>
         </ListBox>
 
 
-            <ContentControl Name="Detail" Grid.Row="3" Grid.ColumnSpan="3"
+        <ContentControl Name="Detail" Grid.Row="3" Grid.ColumnSpan="3"
                         Content="{Binding Source={StaticResource ListingDataView}}"
                         ContentTemplate="{StaticResource DetailsProductListingTemplate}"
                         Margin="9,0,0,0" IsTabStop="False"/>

--- a/Sample Applications/DataBindingDemo/MainWindow.xaml
+++ b/Sample Applications/DataBindingDemo/MainWindow.xaml
@@ -53,14 +53,14 @@
             Sort by category and date
         </CheckBox>
 
-        
+
         <ListBox Name="Master" AutomationProperties.Name="Items For Sale" Grid.Row="2" Grid.ColumnSpan="3" Margin="8"
-                ItemsSource="{Binding Source={StaticResource ListingDataView}}"
-                ItemContainerStyle="{StaticResource AuctionItemContainerStyle}"
-                AutomationProperties.LiveSetting="Assertive">
+                 ItemsSource="{Binding Source={StaticResource ListingDataView}}"
+                 ItemContainerStyle="{StaticResource AuctionItemContainerStyle}"
+                 AutomationProperties.LiveSetting="Assertive">
             <ListBox.GroupStyle>
                 <GroupStyle
-                HeaderTemplate="{StaticResource GroupingHeaderTemplate}" />
+                    HeaderTemplate="{StaticResource GroupingHeaderTemplate}" />
             </ListBox.GroupStyle>
         </ListBox>
 

--- a/Sample Applications/DataBindingDemo/MainWindow.xaml
+++ b/Sample Applications/DataBindingDemo/MainWindow.xaml
@@ -53,19 +53,19 @@
             Sort by category and date
         </CheckBox>
 
-
+        
         <ListBox Name="Master" AutomationProperties.Name="Items For Sale" Grid.Row="2" Grid.ColumnSpan="3" Margin="8"
-                 ItemsSource="{Binding Source={StaticResource ListingDataView}}"
-                 ItemContainerStyle="{StaticResource AuctionItemContainerStyle}"
-                 AutomationProperties.LiveSetting="Assertive">
+            ItemsSource="{Binding Source={StaticResource ListingDataView}}"
+            ItemContainerStyle="{StaticResource AuctionItemContainerStyle}"
+            AutomationProperties.LiveSetting="Assertive">
             <ListBox.GroupStyle>
                 <GroupStyle
-                    HeaderTemplate="{StaticResource GroupingHeaderTemplate}" />
+            HeaderTemplate="{StaticResource GroupingHeaderTemplate}" />
             </ListBox.GroupStyle>
         </ListBox>
 
 
-        <ContentControl Name="Detail" Grid.Row="3" Grid.ColumnSpan="3"
+            <ContentControl Name="Detail" Grid.Row="3" Grid.ColumnSpan="3"
                         Content="{Binding Source={StaticResource ListingDataView}}"
                         ContentTemplate="{StaticResource DetailsProductListingTemplate}"
                         Margin="9,0,0,0" IsTabStop="False"/>

--- a/Sample Applications/DataBindingDemo/Styles.xaml
+++ b/Sample Applications/DataBindingDemo/Styles.xaml
@@ -47,7 +47,6 @@
         <Setter Property="Foreground" Value="#333333" />
         <Setter Property="MaxLength" Value="40" />
         <Setter Property="Width" Value="392" />
-        <Setter Property="Background" Value="Black" />
         <Style.Triggers>
             <!-- High contrast support -->
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true" >

--- a/Sample Applications/DataBindingDemo/Styles.xaml
+++ b/Sample Applications/DataBindingDemo/Styles.xaml
@@ -47,6 +47,7 @@
         <Setter Property="Foreground" Value="#333333" />
         <Setter Property="MaxLength" Value="40" />
         <Setter Property="Width" Value="392" />
+        <Setter Property="Background" Value="Black" />
         <Style.Triggers>
             <!-- High contrast support -->
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true" >
@@ -122,7 +123,7 @@
         <Setter Property="BorderBrush" Value="Black" />
         <Setter Property="Padding" Value="7" />
         <Setter Property="Margin" Value="3" />
-        <Setter Property="Width" Value="500" />
+        <Setter Property="MinWidth" Value="500" />
     </Style>
 
     <Style x:Key="AuctionItemContainerStyle">

--- a/Sample Applications/EditingExaminerDemo/Styles.xaml
+++ b/Sample Applications/EditingExaminerDemo/Styles.xaml
@@ -2,101 +2,102 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:EditingExaminerDemo">
 
-	<Style x:Key="ImmediateWindowLabel" TargetType="Label">
-		<Setter Property="BorderBrush" Value="Gray"/>
-	</Style>
+    <Style x:Key="ImmediateWindowLabel" TargetType="Label">
+        <Setter Property="BorderBrush" Value="Gray"/>
+    </Style>
 
-	<Style x:Key="ErrorMessageTextBox" TargetType="TextBox">
-		<Setter Property="Foreground" Value="DarkRed" />
-		<Setter Property="BorderBrush" Value="Red" />
-		<Setter Property="VerticalAlignment" Value="Center" />
-
-		<Setter Property="Template">
-			<Setter.Value>
+    <Style x:Key="ErrorMessageTextBox" TargetType="TextBox">
+        <Setter Property="Foreground" Value="DarkRed" />
+        <Setter Property="BorderBrush" Value="Red" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Template">
+            <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TextBox}">
                     <Border
-                        x:Name="border"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        Background="{TemplateBinding Background}"
-                        SnapsToDevicePixels="True">
-						<ScrollViewer
-                            x:Name="PART_ContentHost"
-                            Focusable="False"
-                            HorizontalScrollBarVisibility="Hidden"
-                            VerticalScrollBarVisibility="Hidden" />
-					</Border>
+				x:Name="border"
+				BorderBrush="{TemplateBinding BorderBrush}"
+				BorderThickness="{TemplateBinding BorderThickness}"
+				Background="{TemplateBinding Background}"
+				SnapsToDevicePixels="True">
+                        <ScrollViewer
+					x:Name="PART_ContentHost"
+					Focusable="False"
+					HorizontalScrollBarVisibility="Hidden"
+					VerticalScrollBarVisibility="Hidden" />
+                    </Border>
 
-					<ControlTemplate.Triggers>
-						<Trigger Property="IsFocused" Value="True">
-							<Setter Property="BorderBrush" Value="Blue" />
-						</Trigger>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsFocused" Value="True">
+                            <Setter Property="BorderBrush" Value="Blue" />
+                        </Trigger>
 
-						<Trigger Property="IsKeyboardFocused" Value="True">
-							<Setter Property="BorderBrush" Value="Blue" />
-						</Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter Property="BorderBrush" Value="Blue" />
+                        </Trigger>
 
-						<Trigger Property="IsMouseOver" Value="True" >
-							<Setter Property="BorderBrush" Value="Blue" />
-						</Trigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
+                        <Trigger Property="IsMouseOver" Value="True" >
+                            <Setter Property="BorderBrush" Value="Blue" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
 
-		<Style.Triggers>
+        <Style.Triggers>
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}"/>
                 <Setter Property="FontWeight" Value="Bold"/>
                 <Setter Property="FontSize" Value="14"/>
                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
                 <Setter Property="BorderThickness" Value="4" />
+
+            </DataTrigger>
+            
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="XamlSyntaxHighlighterStyle" TargetType="RichTextBox">
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
+                <Setter Property="FontSize" Value="14"/>
             </DataTrigger>
         </Style.Triggers>
-	</Style>
+    </Style>
 
-	<Style x:Key="XamlSyntaxHighlighterStyle" TargetType="RichTextBox">
-		<Style.Triggers>
-			<DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
-				<Setter Property="FontSize" Value="14"/>
-			</DataTrigger>
-		</Style.Triggers>
-	</Style>
-
-	<Style x:Key="TextBoxBorderContrastStyle" TargetType="Control">
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type TextBoxBase}">
-					<Border x:Name="border"
+    <Style x:Key="TextBoxBorderContrastStyle" TargetType="Control">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type TextBoxBase}">
+                    <Border x:Name="border"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         SnapsToDevicePixels="True">
-						<ScrollViewer x:Name="PART_ContentHost"
-                            Focusable="false"
-                            HorizontalScrollBarVisibility="Hidden"
+                        <ScrollViewer x:Name="PART_ContentHost" 
+                            Focusable="false" 
+                            HorizontalScrollBarVisibility="Hidden" 
                             VerticalScrollBarVisibility="Hidden" />
-					</Border>
-					<ControlTemplate.Triggers>
-						<Trigger Property="IsEnabled" Value="false">
-							<Setter TargetName="border" Property="Opacity" Value="0.56"/>
-						</Trigger>
-						<Trigger Property="IsMouseOver" Value="true">
-							<Setter TargetName="border" Property="BorderBrush" Value="Blue" />
-						</Trigger>
-						<Trigger Property="IsKeyboardFocused" Value="true">
-							<Setter TargetName="border" Property="BorderBrush" Value="Blue" />
-						</Trigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
-	<Style x:Key="HelpSectionTextHighContrastStyle" TargetType="Section">
-		<Style.Triggers>
-			<DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true" >
-				<Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
-			</DataTrigger>
-		</Style.Triggers>
-	</Style>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter TargetName="border" Property="Opacity" Value="0.56"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter TargetName="border" Property="BorderBrush" Value="Blue" />
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="true">
+                            <Setter TargetName="border" Property="BorderBrush" Value="Blue" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style x:Key="HelpSectionTextHighContrastStyle" TargetType="Section">
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true" >
+                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
 </ResourceDictionary>

--- a/Sample Applications/EditingExaminerDemo/Styles.xaml
+++ b/Sample Applications/EditingExaminerDemo/Styles.xaml
@@ -2,78 +2,101 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:EditingExaminerDemo">
 
-    <Style x:Key="ImmediateWindowLabel" TargetType="Label">
-        <Setter Property="BorderBrush" Value="Gray"/>
-    </Style>
+	<Style x:Key="ImmediateWindowLabel" TargetType="Label">
+		<Setter Property="BorderBrush" Value="Gray"/>
+	</Style>
 
-    <Style x:Key="ErrorMessageTextBox" TargetType="TextBox">
-        <Setter Property="Foreground" Value="DarkRed" />
-        <Setter Property="BorderBrush" Value="Red" />
-        <Setter Property="VerticalAlignment" Value="Center" />
+	<Style x:Key="ErrorMessageTextBox" TargetType="TextBox">
+		<Setter Property="Foreground" Value="DarkRed" />
+		<Setter Property="BorderBrush" Value="Red" />
+		<Setter Property="VerticalAlignment" Value="Center" />
 
-        <Style.Triggers>
+		<Setter Property="Template">
+			<Setter.Value>
+                <ControlTemplate TargetType="{x:Type TextBox}">
+                    <Border
+                        x:Name="border"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Background="{TemplateBinding Background}"
+                        SnapsToDevicePixels="True">
+						<ScrollViewer
+                            x:Name="PART_ContentHost"
+                            Focusable="False"
+                            HorizontalScrollBarVisibility="Hidden"
+                            VerticalScrollBarVisibility="Hidden" />
+					</Border>
+
+					<ControlTemplate.Triggers>
+						<Trigger Property="IsFocused" Value="True">
+							<Setter Property="BorderBrush" Value="Blue" />
+						</Trigger>
+
+						<Trigger Property="IsKeyboardFocused" Value="True">
+							<Setter Property="BorderBrush" Value="Blue" />
+						</Trigger>
+
+						<Trigger Property="IsMouseOver" Value="True" >
+							<Setter Property="BorderBrush" Value="Blue" />
+						</Trigger>
+					</ControlTemplate.Triggers>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+
+		<Style.Triggers>
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}"/>
                 <Setter Property="FontWeight" Value="Bold"/>
                 <Setter Property="FontSize" Value="14"/>
                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
                 <Setter Property="BorderThickness" Value="4" />
-
-            </DataTrigger>
-            <Trigger Property="IsFocused" Value="true">
-                <Setter Property="BorderBrush" Value="Blue" />
-            </Trigger>
-            <Trigger Property="IsMouseOver" Value="true">
-                <Setter Property="BorderBrush" Value="Blue" />
-            </Trigger>
-            <Trigger Property="IsKeyboardFocused" Value="true">
-                <Setter Property="BorderBrush" Value="Blue" />
-            </Trigger>
-        </Style.Triggers>
-    </Style>
-
-    <Style x:Key="XamlSyntaxHighlighterStyle" TargetType="RichTextBox">
-        <Style.Triggers>
-            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
-                <Setter Property="FontSize" Value="14"/>
             </DataTrigger>
         </Style.Triggers>
-    </Style>
+	</Style>
 
-    <Style x:Key="TextBoxBorderContrastStyle" TargetType="Control">
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type TextBoxBase}">
-                    <Border x:Name="border"
+	<Style x:Key="XamlSyntaxHighlighterStyle" TargetType="RichTextBox">
+		<Style.Triggers>
+			<DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
+				<Setter Property="FontSize" Value="14"/>
+			</DataTrigger>
+		</Style.Triggers>
+	</Style>
+
+	<Style x:Key="TextBoxBorderContrastStyle" TargetType="Control">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="{x:Type TextBoxBase}">
+					<Border x:Name="border"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         SnapsToDevicePixels="True">
-                        <ScrollViewer x:Name="PART_ContentHost" 
-                            Focusable="false" 
-                            HorizontalScrollBarVisibility="Hidden" 
+						<ScrollViewer x:Name="PART_ContentHost"
+                            Focusable="false"
+                            HorizontalScrollBarVisibility="Hidden"
                             VerticalScrollBarVisibility="Hidden" />
-                    </Border>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsEnabled" Value="false">
-                            <Setter TargetName="border" Property="Opacity" Value="0.56"/>
-                        </Trigger>
-                        <Trigger Property="IsMouseOver" Value="true">
-                            <Setter TargetName="border" Property="BorderBrush" Value="Blue" />
-                        </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="true">
-                            <Setter TargetName="border" Property="BorderBrush" Value="Blue" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-    <Style x:Key="HelpSectionTextHighContrastStyle" TargetType="Section">
-        <Style.Triggers>
-            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true" >
-                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
-            </DataTrigger>
-        </Style.Triggers>
-    </Style>
+					</Border>
+					<ControlTemplate.Triggers>
+						<Trigger Property="IsEnabled" Value="false">
+							<Setter TargetName="border" Property="Opacity" Value="0.56"/>
+						</Trigger>
+						<Trigger Property="IsMouseOver" Value="true">
+							<Setter TargetName="border" Property="BorderBrush" Value="Blue" />
+						</Trigger>
+						<Trigger Property="IsKeyboardFocused" Value="true">
+							<Setter TargetName="border" Property="BorderBrush" Value="Blue" />
+						</Trigger>
+					</ControlTemplate.Triggers>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+	<Style x:Key="HelpSectionTextHighContrastStyle" TargetType="Section">
+		<Style.Triggers>
+			<DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true" >
+				<Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
+			</DataTrigger>
+		</Style.Triggers>
+	</Style>
 </ResourceDictionary>

--- a/Sample Applications/EditingExaminerDemo/Styles.xaml
+++ b/Sample Applications/EditingExaminerDemo/Styles.xaml
@@ -10,6 +10,8 @@
         <Setter Property="Foreground" Value="DarkRed" />
         <Setter Property="BorderBrush" Value="Red" />
         <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Margin" Value="2 2 7 1" />
+        
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TextBox}">
@@ -54,15 +56,15 @@
             </DataTrigger>
 
             <Trigger Property="IsFocused" Value="True">
-                <Setter Property="BorderThickness" Value="1.5 1 7 4" />
+                <Setter Property="BorderThickness" Value="1 1 1 6" />
             </Trigger>
 
             <Trigger Property="IsKeyboardFocused" Value="True">
-                <Setter Property="BorderThickness" Value="1.5 1 7 4" />
+                <Setter Property="BorderThickness" Value="1 1 1 6" />
             </Trigger>
 
             <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="BorderThickness" Value="1.5 1 7 4" />
+                <Setter Property="BorderThickness" Value="1 1 1 6" />
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/Sample Applications/EditingExaminerDemo/Styles.xaml
+++ b/Sample Applications/EditingExaminerDemo/Styles.xaml
@@ -52,7 +52,18 @@
                 <Setter Property="BorderThickness" Value="4" />
 
             </DataTrigger>
-            
+
+            <Trigger Property="IsFocused" Value="True">
+                <Setter Property="BorderThickness" Value="1.5 1 7 4" />
+            </Trigger>
+
+            <Trigger Property="IsKeyboardFocused" Value="True">
+                <Setter Property="BorderThickness" Value="1.5 1 7 4" />
+            </Trigger>
+
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="BorderThickness" Value="1.5 1 7 4" />
+            </Trigger>
         </Style.Triggers>
     </Style>
 


### PR DESCRIPTION
Fix Non-text color contrast between keyboard focus and its background.
Fix Keyboard focus not clearly visible.
Fix list of products in 200% zoom are getting truncated.

Issue
A11y_.NET Core_WPF_EditExaminer_Color Contrast: The non-text color contrast between the keyboard focus and its background for "No exception! Warning Box" is 2.296:1 which is < 3:1 #486 
A11y_.NET Core_WPF_EditExaminer_Keyboard: Keyboard focus is not clearly visible on "No exception! Warning Box" #488 
A11y_.NET Core_WPF_DatabindingDemo_ListofProducts_Resize: In 200% zoom, the content under "List of items for sales" are getting truncated. #489 