### PR TITLE
Fixed List of Products in Add Product gets truncated in 200% zoom

### DIFF
--- a/Sample Applications/DataBindingDemo/AddProductWindow.xaml
+++ b/Sample Applications/DataBindingDemo/AddProductWindow.xaml
@@ -37,7 +37,7 @@
                         <RowDefinition />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="106" />
+                        <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 

--- a/Sample Applications/DataBindingDemo/App.xaml
+++ b/Sample Applications/DataBindingDemo/App.xaml
@@ -23,8 +23,8 @@
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="20" />
-                            <ColumnDefinition Width="86" />
-                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition MinWidth="500" />
                         </Grid.ColumnDefinitions>
 
                         <Polygon Grid.Row="0" Grid.Column="0" Grid.RowSpan="4"
@@ -110,7 +110,7 @@
                         <RowDefinition />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="113" />
+                        <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 


### PR DESCRIPTION
Updated the column size from fixed width to auto width. This fixes the truncation issue at 200% zoom.

Issue
A11y_.NET Core_WPF_DatabindingDemo_ListofProducts_Add product listing_Resize: In 200% zoom, the content under "Item for sale" are getting truncated. #491 