### PR TITLE
Fixed Immediate Window gets truncated in 200% Zoom

### DIFF
--- a/Sample Applications/EditingExaminerDemo/MainWindow.xaml
+++ b/Sample Applications/EditingExaminerDemo/MainWindow.xaml
@@ -205,7 +205,7 @@ Selection = RichTextBox.Selection;
             </TabControl>
             <StackPanel Name="Panel3">
                 <Label Name="Label1" BorderThickness="1,0,1,0" Style="{StaticResource ImmediateWindowLabel}" HorizontalContentAlignment="Center"
-                       Width="400" Height="25">
+                       Width="400" Height="Auto" MinHeight="25">
                     Immediate Window
                 </Label>
                 <TextBox Name="ImmediateWindow" AutomationProperties.Name="Immediate Window" Width="400" Height="205" VerticalScrollBarVisibility="Visible"


### PR DESCRIPTION
Changed height and minheight of window to fix immediate window in editing examiner demo gets truncated in 200% zoom.

Issue:
A11y_.NET Core_WPF_EditExaminer_ImmediateWindow_Resize: At 200% zoom, "Immediate Window" control name is getting truncated. #493 