### PR TITLE
Added Focus Triggers to Document Tree View

### DIFF
--- a/Sample Applications/EditingExaminerDemo/MainWindow.xaml
+++ b/Sample Applications/EditingExaminerDemo/MainWindow.xaml
@@ -157,7 +157,7 @@ Selection = RichTextBox.Selection;
                         Width="400" Height="250">
                 <TabItem Header="DocumentTree" 
                          AutomationProperties.HelpText="The DocumentTree Tab displays the entire TreeView of the document container. It demonstrates how to use the TextElementCollection features. It updates automatically on each TextChanged event of the RichTextBox. This allows you to visualize the document hierarchy.">
-                    <TreeView Name="TextTreeView" AutomationProperties.Name="Document Elements"/>
+                    <TreeView Name="TextTreeView" AutomationProperties.Name="Document Elements" Style="{StaticResource DocumentTreeViewBox}"/>
                 </TabItem>
                 <TabItem Header="SelectionXaml" Name="TabSelectionXaml" 
                          AutomationProperties.HelpText="This tab displays the underlying XAML of the selected content within the RichTextBox.">

--- a/Sample Applications/EditingExaminerDemo/Styles.xaml
+++ b/Sample Applications/EditingExaminerDemo/Styles.xaml
@@ -2,6 +2,42 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:EditingExaminerDemo">
 
+
+    <Style x:Key="DocumentTreeViewBox" TargetType="TreeView">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type TreeView}">
+                    <Border
+				        x:Name="border"
+				        BorderBrush="{TemplateBinding BorderBrush}"
+				        BorderThickness="{TemplateBinding BorderThickness}"
+				        Background="{TemplateBinding Background}"
+				        SnapsToDevicePixels="True">
+                        <ScrollViewer
+					        x:Name="PART_ContentHost"
+					        Focusable="False"
+					        HorizontalScrollBarVisibility="Hidden"
+					        VerticalScrollBarVisibility="Hidden" />
+                    </Border>
+
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsFocused" Value="True">
+                            <Setter Property="BorderBrush" Value="Blue" />
+                        </Trigger>
+
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter Property="BorderBrush" Value="Blue" />
+                        </Trigger>
+
+                        <Trigger Property="IsMouseOver" Value="True" >
+                            <Setter Property="BorderBrush" Value="Blue" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    
     <Style x:Key="ImmediateWindowLabel" TargetType="Label">
         <Setter Property="BorderBrush" Value="Gray"/>
     </Style>


### PR DESCRIPTION
Added styles to document tree view and updated Keyboard Focus, Mouseover and Focused triggers to render border.

Issue:
A11y_.NET Core_WPF_EditExaminer_Document Tree_Keyboard: Keyboard focus is not clearly visible on "Document Tree view" #495 