### PR TITLE
Fixed invalid day and month in StickyNotesDemo proj

### DIFF
--- a/Sample Applications/StickyNotesDemo/MainWindow.cs
+++ b/Sample Applications/StickyNotesDemo/MainWindow.cs
@@ -223,14 +223,14 @@ namespace StickyNotesDemo
             var seconds = (int) double.Parse(token);
 
             tail = index + 1;
-            index = line.IndexOf('/', tail);
-            token = line.Substring(tail, (index - tail));
-            var month = int.Parse(token);
-
-            tail = index + 1;
-            index = line.IndexOf('/', tail);
+            index = line.IndexOf('-', tail);
             token = line.Substring(tail, (index - tail));
             var day = int.Parse(token);
+
+            tail = index + 1;
+            index = line.IndexOf('-', tail);
+            token = line.Substring(tail, (index - tail));
+            var month = int.Parse(token);
 
             tail = index + 1;
             index = line.IndexOf('|', tail);


### PR DESCRIPTION
Fixed invalid day and month in StickyNotesDemo proj.

Fixes issue #516 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/522)