### PR TITLE
Adding All Controls Page and Navigations to Fluent Application

### DIFF
--- a/Sample Applications/Win11ThemeGallery/App.xaml.cs
+++ b/Sample Applications/Win11ThemeGallery/App.xaml.cs
@@ -77,6 +77,8 @@ public partial class App : Application
 
             services.AddTransient<LayoutPage>();
             services.AddTransient<LayoutPageViewModel>();
+            services.AddTransient<AllSamplesPage>();
+            services.AddTransient<AllSamplesPageViewModel>();
             services.AddTransient<BasicInputPage>();
             services.AddTransient<BasicInputPageViewModel>();
             services.AddTransient<CollectionsPage>();

--- a/Sample Applications/Win11ThemeGallery/ViewModels/AllSamplesPageViewModel.cs
+++ b/Sample Applications/Win11ThemeGallery/ViewModels/AllSamplesPageViewModel.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media.Imaging;
+using Win11ThemeGallery.Navigation;
+using System.Windows.Controls;
+using Win11ThemeGallery.Views;
+
+namespace Win11ThemeGallery.ViewModels
+{
+    public partial class AllSamplesPageViewModel : ObservableObject
+    {
+        [ObservableProperty]
+        private string _pageTitle = "All Samples";
+
+        [ObservableProperty]
+        private string _pageDescription = "";
+
+        [ObservableProperty]
+        private ICollection<NavigationCard> _navigationCards = new ObservableCollection<NavigationCard>
+        {
+            new NavigationCard
+            {
+                Name = "Button",
+                PageType = typeof(ButtonPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/Button.png"))},
+                //Icon = new SymbolIcon { Symbol = SymbolRegular.ControlButton24 },
+                Description = "A control that responds to user input and raises a Click event."
+            },
+            new NavigationCard
+            {
+                Name = "CheckBox",
+                PageType = typeof(CheckBoxPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/Checkbox.png"))},
+                //Icon = new SymbolIcon { Symbol = SymbolRegular.CheckboxChecked24 },
+                Description = "A control that a user can select or clear."
+            },
+            new NavigationCard
+            {
+                Name = "ComboBox",
+                PageType = typeof(ComboBoxPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/ComboBox.png"))},
+                //Icon = new SymbolIcon { Symbol = SymbolRegular.Filter16 },
+                Description = "A drop-down list of items a user can select from."
+            },
+            new NavigationCard
+            {
+                Name = "RadioButton",
+                PageType = typeof(RadioButtonPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/RadioButton.png"))},
+                //Icon = new SymbolIcon { Symbol = SymbolRegular.RadioButton24 },
+                Description = "A control that allows a user to select a single option from a group of options."
+            },
+            new NavigationCard
+            {
+                Name = "Slider",
+                PageType = typeof(SliderPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/Slider.png"))},
+                //Icon = new SymbolIcon { Symbol = SymbolRegular.HandDraw24 },
+                Description = "A control that lets the user select from a range of values by moving a Thumb control along a track."
+            },
+            new NavigationCard
+            {
+                Name = "Data Grid",
+                PageType = typeof(DataGridPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/DataGrid.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.GridKanban20 },
+                Description = "The DataGrid control presents data in a customizable table of rows and columns."
+            },
+            new NavigationCard
+            {
+                Name = "ListBox",
+                PageType = typeof(ListBoxPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/ListBox.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.AppsListDetail24 },
+                Description = "A control that presents an inline list of items that the user can select from."
+            },
+            new NavigationCard
+            {
+                Name = "ListView",
+                PageType = typeof(ListViewPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/ListView.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.GroupList24 },
+                Description = "A control that presents a collection of items in a vertical list."
+            },
+            new NavigationCard
+            {
+                Name = "TreeView",
+                PageType = typeof(TreeViewPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/TreeView.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.TextBulletListTree24 },
+                Description = "The TreeView control is a hierarchical list pattern with expanding and collapsing nodes that contain nested items."
+            },
+            new NavigationCard
+            {
+                Name = "Calendar",
+                PageType = typeof(CalendarPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/CalendarView.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.CalendarLtr24 },
+                Description = "A control that presents a calendar for a user to choose a date from."
+            },
+            new NavigationCard
+            {
+                Name = "DatePicker",
+                PageType = typeof(DatePickerPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/DatePicker.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.CalendarSearch20 },
+                Description = "A control that lets a user pick a date value."
+            },
+            new NavigationCard
+            {
+                Name = "Expander",
+                PageType = typeof(ExpanderPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/Expander.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.CheckboxChecked24 },
+                Description = "A container with a header that can be expanded to show a body with more content."
+            },
+            new NavigationCard
+            {
+                Name = "Menu",
+                PageType = typeof(MenuPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/Pivot.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.RowTriple24 },
+                Description = "A classic menu, allowing the display of MenuItems containing MenuFlyoutItems."
+            },
+            new NavigationCard
+            {
+                Name = "TabControl",
+                PageType = typeof(TabControlPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/TabView.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.TabDesktopBottom24 },
+                Description = "A control that displays a collection of tabs."
+            },
+            new NavigationCard
+            {
+                Name = "ProgressBar",
+                PageType = typeof(ProgressBarPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/ProgressBar.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.ArrowDownload24 },
+                Description = "Shows the apps progress on a task, or that the app is performing ongoing work that doesn't block user interaction."
+            },
+            new NavigationCard
+            {
+                Name = "ToolTip",
+                PageType = typeof(ToolTipPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/ToolTip.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.Comment24 },
+                Description = "Displays information for an element in a pop-up window."
+            },
+            new NavigationCard
+            {
+                Name = "Label",
+                PageType = typeof(LabelPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/Button.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.TextBaseline20 },
+                Description = "Caption of an item."
+            },
+            new NavigationCard
+            {
+                Name = "TextBlock",
+                PageType = typeof(TextBlockPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/TextBlock.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.TextCaseLowercase24 },
+                Description = "A lightweight control for displaying small amounts of text."
+            },
+            new NavigationCard
+            {
+                Name = "TextBox",
+                PageType = typeof(TextBoxPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/TextBox.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.TextColor24 },
+                Description = "A single-line or multi-line plain text field."
+            },
+            new NavigationCard
+            {
+                Name = "RichTextEdit",
+                PageType = typeof(RichTextEditPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/RichEditBox.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.DrawText24 },
+                Description = "A control that displays formatted text, hyperlinks, inline images, and other rich content."
+            },
+            new NavigationCard
+            {
+                Name = "PasswordBox",
+                PageType = typeof(PasswordBoxPage),
+                Icon = new Image {Source= new BitmapImage(new Uri("pack://application:,,,/Assets/ControlImages/PasswordBox.png"))},
+               // Icon = newSymbolIcon { Symbol = SymbolRegular.Password24 },
+                Description = "A control for entering passwords."
+            },
+        };
+
+        private readonly INavigationService _navigationService;
+
+        public AllSamplesPageViewModel(INavigationService navigationService)
+        {
+            _navigationService = navigationService;
+        }
+
+        [RelayCommand]
+        public void Navigate(object pageType)
+        {
+            if (pageType is Type page)
+            {
+                _navigationService.NavigateTo(page);
+            }
+        }
+
+    }
+}

--- a/Sample Applications/Win11ThemeGallery/ViewModels/MainWindowViewModel.cs
+++ b/Sample Applications/Win11ThemeGallery/ViewModels/MainWindowViewModel.cs
@@ -37,6 +37,12 @@ public partial class MainWindowViewModel : ObservableObject
         },
         new NavigationItem
         {
+            Name = "All Samples",
+            PageType = typeof(AllSamplesPage),
+            Icon = "\xE71D",
+        },
+        new NavigationItem
+        {
             Name = "Basic Input",
             PageType = typeof(BasicInputPage),
             Icon = "\xE73A",

--- a/Sample Applications/Win11ThemeGallery/Views/AllSamplesPage.xaml
+++ b/Sample Applications/Win11ThemeGallery/Views/AllSamplesPage.xaml
@@ -1,0 +1,42 @@
+﻿<Page x:Class="Win11ThemeGallery.Views.AllSamplesPage"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Win11ThemeGallery.Views"
+        mc:Ignorable="d"
+        Title="AllSamplesPage">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" VerticalAlignment="Center" Margin="0 0 0 40">
+            <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" />
+        </StackPanel>
+
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+            <ItemsControl ItemsSource="{Binding ViewModel.NavigationCards}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel Orientation="Horizontal" Margin="10"/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Button Width="360" Height="90" Margin="10" Padding="20 10" HorizontalContentAlignment="Left" Command="{Binding ViewModel.NavigateCommand, RelativeSource={RelativeSource AncestorType={x:Type local:AllSamplesPage}}}" CommandParameter="{Binding PageType}">
+                            <StackPanel Orientation="Horizontal">
+                                <ContentPresenter Width="50" Height="50" Content="{Binding Icon}" Margin="0,0,8,0"/>
+                                <StackPanel Orientation="Vertical">
+                                    <TextBlock Text="{Binding Name}" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="10 0 0 0"/>
+                                    <TextBlock Text="{Binding Description}" Style="{StaticResource CaptionTextBlockStyle}" Margin="10 0 0 0" Width="240" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Button>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </Grid>
+</Page>

--- a/Sample Applications/Win11ThemeGallery/Views/AllSamplesPage.xaml.cs
+++ b/Sample Applications/Win11ThemeGallery/Views/AllSamplesPage.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+using Win11ThemeGallery.ViewModels;
+
+namespace Win11ThemeGallery.Views
+{
+    /// <summary>
+    /// Interaction logic for AllSamplesPage.xaml
+    /// </summary>
+    public partial class AllSamplesPage : Page
+    {
+        public AllSamplesPageViewModel ViewModel { get; }
+        public AllSamplesPage(AllSamplesPageViewModel viewModel)
+        {
+            InitializeComponent();
+            ViewModel = viewModel;
+            DataContext = this;
+        }
+    }
+}


### PR DESCRIPTION
## Description
The following changes adds a section **All Samples** in the tree view of fluent application and includes all the control cards.

## Testing
Fluent Application Builds and runs successfully
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/539)