### PR TITLE
Fix crashing of about page

### DIFF
--- a/Sample Applications/WPFGallery/Views/AboutPage.xaml
+++ b/Sample Applications/WPFGallery/Views/AboutPage.xaml
@@ -91,7 +91,7 @@
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="To clone this repository" />
-                                <TextBlock Grid.Column="2" Style="{StaticResource SelectionTextBox}" Text="git clone https://github.com/microsoft/WPF-Samples.git" />
+                                <TextBox Grid.Column="2" Style="{StaticResource SelectionTextBox}" Text="git clone https://github.com/microsoft/WPF-Samples.git" />
                             </Grid>
                         </Border>
 


### PR DESCRIPTION
Changes the textblock to textbox for the styles to apply properly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/568)