### PR TITLE
Changing the scroll bar's visibility in Icons Page

### DIFF
--- a/Sample Applications/WPFGallery/Views/DesignGuidance/IconsPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/IconsPage.xaml
@@ -95,7 +95,7 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="296"/>
             </Grid.ColumnDefinitions>
-            <ListView Grid.Column="0" ItemsSource="{Binding ViewModel.Icons}" ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Hidden" Padding="4" SelectedItem="{Binding ViewModel.SelectedIcon}" SelectionMode="Single" >
+            <ListView Grid.Column="0" ItemsSource="{Binding ViewModel.Icons}" ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Visible" Padding="4" SelectedItem="{Binding ViewModel.SelectedIcon}" SelectionMode="Single" >
                 <ListView.ItemsPanel>
                     <ItemsPanelTemplate>
                         <WrapPanel Orientation="Horizontal" Margin="10" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>


### PR DESCRIPTION
## Description
The scroll bar in Icons page is not visible and due to large number of icons there, it is very inconvenient to scroll through each of them. The change below, toggles the visibility of vertical scrollbar in icons' page.

## Testing
Gallery Application built and was launching as expected.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/575)