### PR TITLE
Addressed name properties in wpf gallery app

### DIFF
--- a/Sample Applications/WPFGallery/Controls/ControlExample.xaml
+++ b/Sample Applications/WPFGallery/Controls/ControlExample.xaml
@@ -68,7 +68,7 @@
                                             Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                             Text="XAML" />
 
-                                        <Button Grid.Column="1" Padding="8" Command="ApplicationCommands.Copy" CommandParameter="Copy_XamlCode" FocusManager.IsFocusScope="True" ToolTipService.ToolTip="Copy to clipboard" >
+                                        <Button Grid.Column="1" Padding="8" Command="ApplicationCommands.Copy" CommandParameter="Copy_XamlCode" FocusManager.IsFocusScope="True" ToolTipService.ToolTip="Copy to clipboard" AutomationProperties.Name="Copy XAML Code" >
                                           <Grid>
                                             <TextBlock x:Name="CopyGlyphTextBlock" FontFamily="Segoe Fluent Icons" Text="&#xE8C8;"/>
                                             <TextBlock x:Name="SuccessGlyphTextBlock" FontFamily="Segoe Fluent Icons" Text="&#xE73E;" Opacity="0" />

--- a/Sample Applications/WPFGallery/Views/AllSamplesPage.xaml
+++ b/Sample Applications/WPFGallery/Views/AllSamplesPage.xaml
@@ -39,7 +39,7 @@
                             Margin="7"
                             Padding="20,10"
                             HorizontalContentAlignment="Left"
-                            AutomationProperties.Name="{Binding Name}"
+                            AutomationProperties.Name="{Binding Name, StringFormat='{}{0} Page'}"
                             Command="{Binding ViewModel.NavigateCommand, RelativeSource={RelativeSource AncestorType={x:Type local:AllSamplesPage}}}"
                             CommandParameter="{Binding PageType}">
                             <StackPanel Orientation="Horizontal">

--- a/Sample Applications/WPFGallery/Views/BasicInput/RadioButtonPage.xaml
+++ b/Sample Applications/WPFGallery/Views/BasicInput/RadioButtonPage.xaml
@@ -45,18 +45,18 @@
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0">
                             <RadioButton
-                                AutomationProperties.Name="Group 1 Option 1"
+                                AutomationProperties.Name="Standard RadioButton Option 1"
                                 Content="Option 1"
                                 GroupName="radio_group_one"
                                 IsChecked="True"
                                 IsEnabled="{Binding ViewModel.IsRadioButtonEnabled, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:RadioButtonPage}, Mode=OneWay}" />
                             <RadioButton
-                                AutomationProperties.Name="Group 1 Option 2"
+                                AutomationProperties.Name="Standard RadioButton Option 2"
                                 Content="Option 2"
                                 GroupName="radio_group_one"
                                 IsEnabled="{Binding ViewModel.IsRadioButtonEnabled, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:RadioButtonPage}, Mode=OneWay}" />
                             <RadioButton
-                                AutomationProperties.Name="Group 1 Option 3"
+                                AutomationProperties.Name="Standard RadioButton Option 3"
                                 Content="Option 3"
                                 GroupName="radio_group_one"
                                 IsEnabled="{Binding ViewModel.IsRadioButtonEnabled, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:RadioButtonPage}, Mode=OneWay}" />
@@ -75,18 +75,18 @@
                     XamlCode="&lt;StackPanel&gt;             &#10;&#9;&lt;RadioButton Content=&quot;Option 1&quot; FlowDirection=&quot;RightToLeft&quot; GroupName=&quot;radio_group_one&quot; IsChecked=&quot;True&quot;/&gt;             &#10;&#9;&lt;RadioButton Content=&quot;Option 2&quot; FlowDirection=&quot;RightToLeft&quot; GroupName=&quot;radio_group_one&quot; /&gt;             &#10;&#9;&lt;RadioButton Content=&quot;Option 3&quot; FlowDirection=&quot;RightToLeft&quot; GroupName=&quot;radio_group_one&quot; /&gt;             &#10;&lt;/StackPanel&gt;">
                     <StackPanel Grid.Column="0">
                         <RadioButton
-                            AutomationProperties.Name="Group 2 Option 1"
+                            AutomationProperties.Name="Left Flow RadioButton Option 1"
                             Content="Option 1"
                             FlowDirection="RightToLeft"
                             GroupName="radio_group_two"
                             IsChecked="True" />
                         <RadioButton
-                            AutomationProperties.Name="Group 2 Option 2"
+                            AutomationProperties.Name="Left Flow RadioButton Option 2"
                             Content="Option 2"
                             FlowDirection="RightToLeft"
                             GroupName="radio_group_two" />
                         <RadioButton
-                            AutomationProperties.Name="Group 2 Option 3"
+                            AutomationProperties.Name="Left Flow RadioButton Option 3"
                             Content="Option 3"
                             FlowDirection="RightToLeft"
                             GroupName="radio_group_two" />

--- a/Sample Applications/WPFGallery/Views/DateAndTime/DatePickerPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DateAndTime/DatePickerPage.xaml
@@ -40,7 +40,7 @@
                 <DatePicker
                     MinWidth="200"
                     HorizontalAlignment="Left"
-                    AutomationProperties.Name="Default" />
+                    AutomationProperties.Name="Pick a date" />
             </controls:ControlExample>
         </ScrollViewer>
     </Grid>

--- a/Sample Applications/WPFGallery/Views/DesignGuidance/IconsPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/IconsPage.xaml
@@ -36,6 +36,7 @@
                                     Padding="8" 
                                     FocusManager.IsFocusScope="True" 
                                     Command="ApplicationCommands.Copy" 
+                                    AutomationProperties.Name="Copy to clipboard"
                                     ToolTipService.ToolTip="Copy to clipboard"
                                     CommandParameter="{TemplateBinding Content}"
                                     CommandTarget="{Binding RelativeSource={RelativeSource AncestorType=Page}}">

--- a/Sample Applications/WPFGallery/Views/StatusAndInfo/ToolTipPage.xaml
+++ b/Sample Applications/WPFGallery/Views/StatusAndInfo/ToolTipPage.xaml
@@ -41,6 +41,7 @@
                     Content="Button with a simple ToolTip."
                     ToolTipService.InitialShowDelay="100"
                     ToolTipService.Placement="MousePoint"
+                    AutomationProperties.Name="Tooltip Button"
                     ToolTipService.ToolTip="Simple ToolTip" />
             </controls:ControlExample>
         </ScrollViewer>


### PR DESCRIPTION
Addressed following issues in wpf gallery app- 

- [[WPF Gallery->All Samples]: The name property is same as Localized Control type for Button in the All Samples page.
- [WPF Gallery->Date & Calendar->Date Picker]: The Name property of Date Picker button is not defined in the Date Picker page.
- [WPF Gallery->Date & Calendar->Calendar]: The Name property of Next and Previous buttons are not defined in the Calendar.
- [WPF Gallery->Status& Info->Tooltip]: The Name property must not include the element's control type
- [[WPF Gallery->All Samples]: The name property is same as Localized Control type for Button in the All Samples page.
- [[WPF Gallery->All Samples]: The name property is same as Control Type for Button in the All Samples page.
- [WPF Gallery->Design Guidance->Typography]: The name property is not defined for the Copy button and Scroller in the Typography 
- [WPF Gallery->Basic Input->Radio Button]: The name property is not defined descriptively for the radio buttons in the Radio button page.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/595)