### PR TITLE
Fix for "[WPF Gallery->Navigation->Tab control]: Narrator focus is navigating to empty area and announcing as 'text below the heading in every page."

### DIFF
--- a/Sample Applications/WPFGallery/Views/BasicInput/ButtonPage.xaml
+++ b/Sample Applications/WPFGallery/Views/BasicInput/ButtonPage.xaml
@@ -27,7 +27,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/BasicInput/CheckBoxPage.xaml
+++ b/Sample Applications/WPFGallery/Views/BasicInput/CheckBoxPage.xaml
@@ -30,7 +30,6 @@
                     Grid.Column="0"
                     Style="{StaticResource TitleTextBlockStyle}"
                     Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/BasicInput/ComboBoxPage.xaml
+++ b/Sample Applications/WPFGallery/Views/BasicInput/ComboBoxPage.xaml
@@ -27,7 +27,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/BasicInput/RadioButtonPage.xaml
+++ b/Sample Applications/WPFGallery/Views/BasicInput/RadioButtonPage.xaml
@@ -27,7 +27,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/BasicInput/SliderPage.xaml
+++ b/Sample Applications/WPFGallery/Views/BasicInput/SliderPage.xaml
@@ -27,7 +27,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/Collections/DataGridPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Collections/DataGridPage.xaml
@@ -28,7 +28,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/Collections/ListBoxPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Collections/ListBoxPage.xaml
@@ -27,7 +27,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/Collections/ListViewPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Collections/ListViewPage.xaml
@@ -28,7 +28,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/Collections/TreeViewPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Collections/TreeViewPage.xaml
@@ -27,7 +27,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/DateAndTime/CalendarPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DateAndTime/CalendarPage.xaml
@@ -27,7 +27,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/DateAndTime/DatePickerPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DateAndTime/DatePickerPage.xaml
@@ -27,7 +27,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/Layout/ExpanderPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Layout/ExpanderPage.xaml
@@ -27,7 +27,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/Navigation/MenuPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Navigation/MenuPage.xaml
@@ -27,7 +27,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/Navigation/TabControlPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Navigation/TabControlPage.xaml
@@ -27,7 +27,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/StatusAndInfo/ProgressBarPage.xaml
+++ b/Sample Applications/WPFGallery/Views/StatusAndInfo/ProgressBarPage.xaml
@@ -27,7 +27,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>

--- a/Sample Applications/WPFGallery/Views/StatusAndInfo/ToolTipPage.xaml
+++ b/Sample Applications/WPFGallery/Views/StatusAndInfo/ToolTipPage.xaml
@@ -27,7 +27,6 @@
 
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding ViewModel.PageTitle}" AutomationProperties.HeadingLevel="Level1" />
-                <TextBlock Text="{Binding ViewModel.PageDescription}" />
             </StackPanel>
 
         </Grid>


### PR DESCRIPTION
### Description
[WPF Gallery->Navigation->Tab control]: Narrator focus is navigating to empty area and announcing as 'text below the heading in every page.

### User Impact
Who rely on the screen reader users will not understand the context if narrator announce inappropriate announcement.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/602)