### PR TITLE
Removed the selectionchanged event and replaced with mouseup and keydown event to disable right pane getting opened upon getting immediate focus with keyboard.

### DIFF
--- a/Sample Applications/WPFGallery/MainWindow.xaml
+++ b/Sample Applications/WPFGallery/MainWindow.xaml
@@ -205,7 +205,8 @@
                     Margin="8,24,0,0"
                     AutomationProperties.Name="Navigation Pane"
                     ItemsSource="{Binding ViewModel.Controls}"
-                    SelectedItemChanged="ControlsList_SelectedItemChanged">
+                    PreviewKeyDown="ControlsList_PreviewKeyDown"
+                    PreviewMouseLeftButtonUp="ControlsList_PreviewMouseLeftButtonUp">
                     <TreeView.ItemTemplate>
                         <HierarchicalDataTemplate ItemsSource="{Binding Children}">
                             <Grid MinHeight="30">

--- a/Sample Applications/WPFGallery/MainWindow.xaml.cs
+++ b/Sample Applications/WPFGallery/MainWindow.xaml.cs
@@ -165,6 +165,7 @@ public partial class MainWindow : Window
             if(selectedTreeViewItem != null)
             {
                 selectedTreeViewItem.IsSelected = true;
+                ControlsList_SelectedItemChanged();
             }
         }
     }

--- a/Sample Applications/WPFGallery/MainWindow.xaml.cs
+++ b/Sample Applications/WPFGallery/MainWindow.xaml.cs
@@ -66,7 +66,7 @@ public partial class MainWindow : Window
 
     public MainWindowViewModel ViewModel { get; }
 
-    private void ControlsList_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+    private void ControlsList_SelectedItemChanged()
     {
         if (ControlsList.SelectedItem is NavigationItem navItem)
         {
@@ -167,5 +167,18 @@ public partial class MainWindow : Window
                 selectedTreeViewItem.IsSelected = true;
             }
         }
+    }
+
+    private void ControlsList_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter) 
+        {
+            ControlsList_SelectedItemChanged();
+        }
+    }
+
+    private void ControlsList_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        ControlsList_SelectedItemChanged();
     }
 }


### PR DESCRIPTION
Removed the selectionchanged event and replaced with mouseup and keydown event to disable right pane getting opened upon getting immediate focus with keyboard.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/607)