### PR TITLE
Addressed icon contrast ratio on IconsPage

### DIFF
--- a/Sample Applications/WPFGallery/Views/DesignGuidance/IconsPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/IconsPage.xaml
@@ -160,7 +160,7 @@
                                             <RowDefinition Height="Auto" />
                                         </Grid.RowDefinitions>
                                         <TextBlock Focusable="False" Grid.Row="0" FontFamily="Segoe Fluent Icons" Text="{Binding Character}" FontSize="28" Width="28" Height="28" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                                        <TextBlock Focusable="False" Grid.Row="1" Text="{Binding Name}" Style="{StaticResource CaptionTextBlockStyle}" HorizontalAlignment="Center" VerticalAlignment="Bottom" Foreground="{DynamicResource TextFillColorSecondaryBrush}" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap" Margin="6,-4,6,8"/>
+                                        <TextBlock Focusable="False" Grid.Row="1" Text="{Binding Name}" Style="{StaticResource CaptionTextBlockStyle}" HorizontalAlignment="Center" VerticalAlignment="Bottom" Foreground="{DynamicResource TextFillColorPrimaryBrush}" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap" Margin="6,-4,6,8"/>
                                     </Grid>
                                 </Border>
                             </DataTemplate>


### PR DESCRIPTION
Addressed issue : [WPF Gallery->Samples->Icons]: Color contrast ratio of text under icons is 3.152:1 which is less than the required ratio of 4.5:1.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/641)