### PR TITLE
Addressed contrast ratio on user dashboard page

### DIFF
--- a/Sample Applications/WPFGallery/Views/Samples/UserDashboardPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Samples/UserDashboardPage.xaml
@@ -156,19 +156,19 @@
                                 Grid.Column="0"
                                 Margin="0,0,10,0"
                                 Orientation="Vertical">
-                                <Label Content="First Name" FontWeight="SemiBold" />
+                                <Label Content="First Name" Style="{StaticResource GenericLabelStyle}" FontWeight="SemiBold" />
                                 <TextBox AutomationProperties.Name="First Name" Margin="0,5,0,15" Text="{Binding ViewModel.EditableUser.FirstName}" IsReadOnly="{Binding ViewModel.IsRead}"/>
                             </StackPanel>
                             <StackPanel Grid.Column="1" Orientation="Vertical">
-                                <Label Content="Last Name" FontWeight="SemiBold" />
+                                <Label Content="Last Name" Style="{StaticResource GenericLabelStyle}" FontWeight="SemiBold" />
                                 <TextBox AutomationProperties.Name="Last Name" Margin="0,5,0,15" Text="{Binding ViewModel.EditableUser.LastName}" IsReadOnly="{Binding ViewModel.IsRead}"/>
                             </StackPanel>
                         </Grid>
 
-                        <Label Content="Company" FontWeight="SemiBold" />
+                        <Label Content="Company" Style="{StaticResource GenericLabelStyle}" FontWeight="SemiBold" />
                         <TextBox AutomationProperties.Name="Company" Margin="0,5,0,15" Text="{Binding ViewModel.EditableUser.Company}" IsReadOnly="{Binding ViewModel.IsRead}"/>
 
-                        <Label Content="Address" FontWeight="SemiBold" />
+                        <Label Content="Address" Style="{StaticResource GenericLabelStyle}" FontWeight="SemiBold" />
                         <TextBox AutomationProperties.Name="Address" Margin="0,5,0,15" Text="{Binding ViewModel.EditableUser.Address}" IsReadOnly="{Binding ViewModel.IsRead}"/>
 
                         <Grid>
@@ -176,7 +176,7 @@
                                 <ColumnDefinition Width="Auto"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <Label Content="Age" Grid.Column="0" FontWeight="SemiBold" />
+                            <Label Style="{StaticResource GenericLabelStyle}" Content="Age" Grid.Column="0" FontWeight="SemiBold" />
                             <TextBlock Padding="10 0 0 0" Grid.Column="1" Text="{Binding ViewModel.EditableUser.Age}" />
                         </Grid>
                         <Slider
@@ -187,7 +187,7 @@
                             IsSnapToTickEnabled="True"
                             Value="{Binding ViewModel.EditableUser.Age}" IsEnabled="{Binding ViewModel.IsEditing}"/>
 
-                        <Label Content="Date of Joining" FontWeight="SemiBold" />
+                        <Label Content="Date of Joining" Style="{StaticResource GenericLabelStyle}" FontWeight="SemiBold" />
                         <DatePicker AutomationProperties.Name="Date of Joining" Margin="0,5,0,15" SelectedDate="{Binding ViewModel.EditableUser.DateOfJoining}" IsEnabled="{Binding ViewModel.IsEditing}"/>
 
                         <StackPanel Margin="0,5,0,15" Orientation="Horizontal">


### PR DESCRIPTION
Addressed issue :  [WPF Gallery->Samples->User Dashboard->Edit]: Color contrast ratio of text of user details(ex:firstname) is 3.166:1 which is less than the required ratio of 4.5:1.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/642)