### PR TITLE
Resolving Name property must not include the element's control type bug

### DIFF
--- a/Sample Applications/WPFGallery/Views/AllSamplesPage.xaml
+++ b/Sample Applications/WPFGallery/Views/AllSamplesPage.xaml
@@ -39,7 +39,7 @@
                             Margin="7"
                             Padding="20,10"
                             HorizontalContentAlignment="Left"
-                            AutomationProperties.Name="{Binding Title, StringFormat='{}{0} Page'}"
+                            AutomationProperties.Name="{Binding Title, StringFormat='{}{0}Page'}"
                             Command="{Binding ViewModel.NavigateCommand, RelativeSource={RelativeSource AncestorType={x:Type local:AllSamplesPage}}}"
                             CommandParameter="{Binding PageType}">
                             <StackPanel Orientation="Horizontal">

--- a/Sample Applications/WPFGallery/Views/BasicInputPage.xaml
+++ b/Sample Applications/WPFGallery/Views/BasicInputPage.xaml
@@ -43,7 +43,7 @@
                         Margin="7"
                         Padding="20,10"
                         HorizontalContentAlignment="Left"
-                        AutomationProperties.Name="{Binding Title, StringFormat='{}{0} Page'}"
+                        AutomationProperties.Name="{Binding Title, StringFormat='{}{0}Page'}"
                         Command="{Binding ViewModel.NavigateCommand, RelativeSource={RelativeSource AncestorType={x:Type local:BasicInputPage}}}"
                         CommandParameter="{Binding PageType}">
                         <StackPanel Orientation="Horizontal">

--- a/Sample Applications/WPFGallery/Views/StatusAndInfo/ToolTipPage.xaml
+++ b/Sample Applications/WPFGallery/Views/StatusAndInfo/ToolTipPage.xaml
@@ -40,7 +40,7 @@
                     Content="Button with a simple ToolTip."
                     ToolTipService.InitialShowDelay="100"
                     ToolTipService.Placement="MousePoint"
-                    AutomationProperties.Name="Tooltip Button"
+                    AutomationProperties.Name="TooltipButton"
                     ToolTipService.ToolTip="Simple ToolTip" />
             </controls:ControlExample>
         </ScrollViewer>


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/646)