### PR TITLE
Fixes narrator not announcing Source Code Copied upon invoking the copy button

### DIFF
--- a/Sample Applications/WPFGallery/Controls/ColorTile.xaml.cs
+++ b/Sample Applications/WPFGallery/Controls/ColorTile.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Documents;
+﻿using System.Windows.Automation.Peers;
+using System.Windows.Automation;
+using System.Windows.Documents;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 
@@ -85,6 +87,14 @@ namespace WPFGallery.Controls
                     try
                     {
                         Clipboard.SetText(colorTile.ColorBrushName);
+                        AutomationPeer peer = UIElementAutomationPeer.CreatePeerForElement((ColorTile)e.OriginalSource);
+                        peer.RaiseNotificationEvent(
+                           AutomationNotificationKind.Other,
+                            AutomationNotificationProcessing.ImportantMostRecent,
+                            "Color Brush Name Copied",
+                            "ButtonClickedActivity"
+                        );
+
                     }
                     catch (Exception ex)
                     {

--- a/Sample Applications/WPFGallery/Controls/ControlExample.xaml.cs
+++ b/Sample Applications/WPFGallery/Controls/ControlExample.xaml.cs
@@ -4,6 +4,8 @@
 // All Rights Reserved.
 
 using System.IO;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation;
 
 namespace WPFGallery.Controls;
 
@@ -125,6 +127,13 @@ public class ControlExample : Control
                     {
                         case "Copy_XamlCode":
                             Clipboard.SetText(controlExample.XamlCode);
+                            AutomationPeer peer = UIElementAutomationPeer.CreatePeerForElement((Button)e.OriginalSource);
+                            peer.RaiseNotificationEvent(
+                                AutomationNotificationKind.Other,
+                                AutomationNotificationProcessing.ImportantMostRecent,
+                                "Source Code Copied",
+                                "ButtonClickedActivity"
+                            );
                             break;
                         case "Copy_CsharpCode":
                             Clipboard.SetText(controlExample.CsharpCode);


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/649)