### PR TITLE
Addressed contrast ratio

### DIFF
--- a/Sample Applications/WPFGallery/Views/DesignGuidance/IconsPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/IconsPage.xaml
@@ -160,7 +160,7 @@
                                             <RowDefinition Height="Auto" />
                                         </Grid.RowDefinitions>
                                         <TextBlock Focusable="False" Grid.Row="0" FontFamily="Segoe Fluent Icons" Text="{Binding Character}" FontSize="28" Width="28" Height="28" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                                        <TextBlock Focusable="False" Grid.Row="1" Text="{Binding Name}" Style="{StaticResource CaptionTextBlockStyle}" HorizontalAlignment="Center" VerticalAlignment="Bottom" Foreground="{DynamicResource TextFillColorSecondaryBrush}" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap" Margin="6,-4,6,8"/>
+                                        <TextBlock Focusable="False" Grid.Row="1" Text="{Binding Name}" Style="{StaticResource CaptionTextBlockStyle}" HorizontalAlignment="Center" VerticalAlignment="Bottom" Foreground="{DynamicResource TextFillColorPrimaryBrush}" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap" Margin="6,-4,6,8"/>
                                     </Grid>
                                 </Border>
                             </DataTemplate>

--- a/Sample Applications/WPFGallery/Views/Samples/UserDashboardPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Samples/UserDashboardPage.xaml
@@ -75,13 +75,14 @@
                                 Grid.Row="0"
                                 Grid.Column="1"
                                 Margin="12,6,0,0"
-                                Text="{Binding Name, Mode=OneWay}" />
+                                Text="{Binding Name, Mode=OneWay}" 
+                                AutomationProperties.HeadingLevel="Level3" />
                             <TextBlock
                                 Grid.Row="1"
                                 Grid.Column="1"
                                 Margin="12,0,0,6"
                                 Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                Opacity="0.67"
+                                Opacity="0.7"
                                 Text="{Binding Company, Mode=OneWay}" />
                         </Grid>
                     </DataTemplate>

--- a/Sample Applications/WPFGallery/Views/Samples/UserDashboardPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Samples/UserDashboardPage.xaml
@@ -82,7 +82,7 @@
                                 Grid.Column="1"
                                 Margin="12,0,0,6"
                                 Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                Opacity="0.7"
+                                Opacity="0.8"
                                 Text="{Binding Company, Mode=OneWay}" />
                         </Grid>
                     </DataTemplate>


### PR DESCRIPTION
This fixes :
1. [WPF Gallery->Samples->User Dashboard]: Color contrast ratio of text under selected username is 4.409:1 which is less than the required ratio of 4.5:1.
2. [WPF Gallery->Samples->Icons]: Color contrast ratio of text under icons is 3.179:1 which is less than the required ratio of 4.5:1.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/651)