### PR TITLE
Fix Icons not being displayed in Windows 10

### DIFF
--- a/Sample Applications/WPFGallery/Controls/ColorTile.xaml
+++ b/Sample Applications/WPFGallery/Controls/ColorTile.xaml
@@ -59,8 +59,8 @@
                                     FocusManager.IsFocusScope="True"
                                     ToolTipService.ToolTip="Copy brush name">
                                     <Grid>
-                                        <TextBlock x:Name="CopyGlyphTextBlock" FontFamily="Segoe Fluent Icons" FontSize="16" Text="&#xE8C8;" />
-                                        <TextBlock x:Name="SuccessGlyphTextBlock" FontFamily="Segoe Fluent Icons" FontSize="16" Text="&#xE73E;" Opacity="0" />
+                                        <TextBlock x:Name="CopyGlyphTextBlock" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="16" Text="&#xE8C8;" />
+                                        <TextBlock x:Name="SuccessGlyphTextBlock" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="16" Text="&#xE73E;" Opacity="0" />
                                     </Grid>
                                     <Button.Triggers>
                                         <EventTrigger RoutedEvent="Button.Click">
@@ -105,7 +105,7 @@
                                     <TextBlock
                                         FontSize="16"
                                         Foreground="{DynamicResource SystemFillColorCriticalBrush}"
-                                        FontFamily="Segoe Fluent Icons"
+                                        FontFamily="{StaticResource SymbolThemeFontFamily}"
                                         Text="&#xE7BA;" />
                                 </Grid>
                             </Grid>

--- a/Sample Applications/WPFGallery/Controls/ControlExample.xaml
+++ b/Sample Applications/WPFGallery/Controls/ControlExample.xaml
@@ -70,8 +70,8 @@
 
                                         <Button Grid.Column="1" Padding="8" Command="ApplicationCommands.Copy" CommandParameter="Copy_XamlCode" ToolTipService.ToolTip="Copy to clipboard" AutomationProperties.Name="Copy XAML Code" >
                                           <Grid>
-                                            <TextBlock x:Name="CopyGlyphTextBlock" FontFamily="Segoe Fluent Icons" Text="&#xE8C8;"/>
-                                            <TextBlock x:Name="SuccessGlyphTextBlock" FontFamily="Segoe Fluent Icons" Text="&#xE73E;" Opacity="0" />
+                                                <TextBlock x:Name="CopyGlyphTextBlock" FontFamily="{StaticResource SymbolThemeFontFamily}" Text="&#xE8C8;"/>
+                                                <TextBlock x:Name="SuccessGlyphTextBlock" FontFamily="{StaticResource SymbolThemeFontFamily}" Text="&#xE73E;" Opacity="0" />
                                           </Grid>  
                                             <Button.Triggers>
                                               <EventTrigger RoutedEvent="Button.Click">
@@ -122,7 +122,7 @@
                                             Text="C#" />
 
                                         <Button Grid.Column="1" Padding="8" Command="ApplicationCommands.Copy" CommandParameter="Copy_CsharpCode" FocusManager.IsFocusScope="True" >
-                                            <TextBlock FontFamily="Segoe Fluent Icons" Text="&#xE8C8;" />
+                                            <TextBlock FontFamily="{StaticResource SymbolThemeFontFamily}" Text="&#xE8C8;" />
                                         </Button>
                                     </Grid>
                                     <TextBox

--- a/Sample Applications/WPFGallery/MainWindow.xaml
+++ b/Sample Applications/WPFGallery/MainWindow.xaml
@@ -108,7 +108,7 @@
                 ToolTipService.ToolTip="Back">
                 <TextBlock
                     VerticalAlignment="Center"
-                    FontFamily="Segoe Fluent Icons"
+                    FontFamily="{StaticResource SymbolThemeFontFamily}"
                     FontSize="12"
                     Text="&#xE72B;">
                     <TextBlock.Style>
@@ -151,7 +151,7 @@
                 WindowChrome.IsHitTestVisibleInChrome="True">
                 <TextBlock
                     VerticalAlignment="Center"
-                    FontFamily="Segoe Fluent Icons"
+                    FontFamily="{StaticResource SymbolThemeFontFamily}"
                     FontSize="12"
                     Text="&#xE921;" />
             </Button>
@@ -168,7 +168,7 @@
                 <TextBlock
                     x:Name="MaximizeIcon"
                     VerticalAlignment="Center"
-                    FontFamily="Segoe Fluent Icons"
+                    FontFamily="{StaticResource SymbolThemeFontFamily}"
                     FontSize="12"
                     Text="&#xE922;" />
             </Button>
@@ -184,7 +184,7 @@
                 WindowChrome.IsHitTestVisibleInChrome="True">
                 <TextBlock
                     VerticalAlignment="Center"
-                    FontFamily="Segoe Fluent Icons"
+                    FontFamily="{StaticResource SymbolThemeFontFamily}"
                     FontSize="16"
                     Text="&#xE711;" />
             </Button>
@@ -233,7 +233,7 @@
                                     VerticalAlignment="Center"
                                     AutomationProperties.Name="{Binding Title, StringFormat='{}{0} Page'}"
                                     Focusable="False"
-                                    FontFamily="Segoe Fluent Icons"
+                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
                                     FontSize="16"
                                     Text="{Binding IconGlyph}"
                                     Visibility="{Binding IconGlyph, Converter={StaticResource EmptyToVisibilityConverter}}" />
@@ -257,7 +257,7 @@
                         Click="AboutButton_Click"
                         DockPanel.Dock="Bottom">
                         <StackPanel Orientation="Horizontal">
-                            <TextBlock Margin="0,4,0,0" FontFamily="Segoe Fluent Icons">&#xE946;</TextBlock>
+                            <TextBlock Margin="0,4,0,0" FontFamily="{StaticResource SymbolThemeFontFamily}">&#xE946;</TextBlock>
                             <TextBlock Margin="8,0,0,0" Text="About" />
                         </StackPanel>
                     </Button>

--- a/Sample Applications/WPFGallery/Views/AboutPage.xaml
+++ b/Sample Applications/WPFGallery/Views/AboutPage.xaml
@@ -105,7 +105,7 @@
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="File a bug or request a new sample" />
                                 <Button AutomationProperties.Name="Open Issues" Grid.Column="2" Padding="8" FocusManager.IsFocusScope="True" Click="Open_Issues">
-                                    <TextBlock FontFamily="Segoe Fluent Icons" Text="&#xe8a7;" />
+                                    <TextBlock FontFamily="{StaticResource SymbolThemeFontFamily}" Text="&#xe8a7;" />
                                 </Button>
                             </Grid>
                         </Border>

--- a/Sample Applications/WPFGallery/Views/DesignGuidance/IconsPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/IconsPage.xaml
@@ -42,8 +42,8 @@
                                     CommandParameter="{TemplateBinding Content}"
                                     CommandTarget="{Binding RelativeSource={RelativeSource AncestorType=Page}}">
                                 <Grid>
-                                    <TextBlock x:Name="CopyGlyphTextBlock" FontFamily="Segoe Fluent Icons" Text="&#xE8C8;"/>
-                                    <TextBlock x:Name="SuccessGlyphTextBlock" FontFamily="Segoe Fluent Icons" Text="&#xE73E;" Opacity="0" />
+                                    <TextBlock x:Name="CopyGlyphTextBlock" FontFamily="{StaticResource SymbolThemeFontFamily}" Text="&#xE8C8;"/>
+                                    <TextBlock x:Name="SuccessGlyphTextBlock" FontFamily="{StaticResource SymbolThemeFontFamily}" Text="&#xE73E;" Opacity="0" />
                                 </Grid>
                                 <Button.Triggers>
                                     <EventTrigger RoutedEvent="Button.Click">
@@ -122,11 +122,11 @@
                     </Span>
                     <LineBreak/>
                     <Span>
-                        &lt;TextBlock FontFamily="Segoe Fluent Icons" Text="&amp;#xEB51;" Foreground="#C72335"/&gt;
+                        &lt;TextBlock FontFamily="{StaticResource SymbolThemeFontFamily}" Text="&amp;#xEB51;" Foreground="#C72335"/&gt;
                     </Span>
                     <LineBreak/>
                     <Span>
-                        &#x09;&lt;TextBlock FontFamily="Segoe Fluent Icons" Text="&amp;#xEB51;" /&gt;
+                        &#x09;&lt;TextBlock FontFamily="{StaticResource SymbolThemeFontFamily}" Text="&amp;#xEB51;" /&gt;
                     </Span>
                     <LineBreak/>
                     <Span>
@@ -159,7 +159,7 @@
                                             <RowDefinition Height="*" />
                                             <RowDefinition Height="Auto" />
                                         </Grid.RowDefinitions>
-                                        <TextBlock Focusable="False" Grid.Row="0" FontFamily="Segoe Fluent Icons" Text="{Binding Character}" FontSize="28" Width="28" Height="28" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                        <TextBlock Focusable="False" Grid.Row="0" FontFamily="{StaticResource SymbolThemeFontFamily}" Text="{Binding Character}" FontSize="28" Width="28" Height="28" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                                         <TextBlock Focusable="False" Grid.Row="1" Text="{Binding Name}" Style="{StaticResource CaptionTextBlockStyle}" HorizontalAlignment="Center" VerticalAlignment="Bottom" Foreground="{DynamicResource TextFillColorPrimaryBrush}" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap" Margin="6,-4,6,8"/>
                                     </Grid>
                                 </Border>
@@ -169,7 +169,7 @@
                     <Grid Grid.Column="1" Background="{DynamicResource ButtonBackground}">
                         <StackPanel Orientation="Vertical" Margin="16">
                             <TextBlock Text="{Binding ViewModel.SelectedIcon.Name}" Style="{StaticResource SubtitleTextBlockStyle}" VerticalAlignment="Center"/>
-                            <TextBlock Text="{Binding ViewModel.SelectedIcon.Character}" FontFamily="Segoe Fluent Icons" FontSize="50" Margin="0,12,0,32" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                            <TextBlock Text="{Binding ViewModel.SelectedIcon.Character}" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="50" Margin="0,12,0,32" HorizontalAlignment="Left" VerticalAlignment="Center"/>
                             <TextBlock Text="Icon Name"/>
                             <ContentControl Style="{StaticResource IconData}" Content="{Binding ViewModel.SelectedIcon.Name}"/>
                             <TextBlock Text="Unicode point"/>
@@ -179,7 +179,7 @@
                             <TextBlock Text="Code glyph"/>
                             <ContentControl Style="{StaticResource IconData}" Content="{Binding ViewModel.SelectedIcon.CodeGlyph}"/>
                             <TextBlock Text="XAML"/>
-                            <TextBlock x:Name="XAMLCode" Text="{Binding ViewModel.SelectedIcon.TextGlyph, StringFormat='&lt;TextBlock FontFamily=&#x22;Segoe Fluent Icons&#x22; Text=&#x22;{0}&#x22;/&gt;'}" Visibility="Collapsed"/>
+                            <TextBlock x:Name="XAMLCode" Text="{Binding ViewModel.SelectedIcon.TextGlyph, StringFormat='&lt;TextBlock FontFamily=&#x22;{{StaticResource SymbolThemeFontFamily}}&#x22; Text=&#x22;{0}&#x22;/&gt;'}" Visibility="Collapsed"/>
                             <ContentControl Style="{StaticResource IconData}" Content="{Binding ElementName=XAMLCode, Path=Text}" />
                         </StackPanel>
                     </Grid>

--- a/Sample Applications/WPFGallery/Views/Navigation/MenuPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Navigation/MenuPage.xaml
@@ -74,7 +74,7 @@
                                     <TextBlock
                                     AutomationProperties.Name="Bold"
                                     Focusable="False"
-                                    FontFamily="Segoe Fluent Icons"
+                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
                                     FontSize="12"
                                     Text="&#xE8DD;" />
                                 </MenuItem.Header>
@@ -85,7 +85,7 @@
                                     <TextBlock
                                     AutomationProperties.Name="Italic"
                                     Focusable="False"
-                                    FontFamily="Segoe Fluent Icons"
+                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
                                     FontSize="12"
                                     Text="&#xE8DB;" />
                                 </MenuItem.Header>
@@ -96,7 +96,7 @@
                                     <TextBlock
                                     AutomationProperties.Name="Underlined"
                                     Focusable="False"
-                                    FontFamily="Segoe Fluent Icons"
+                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
                                     FontSize="12"
                                     Text="&#xE8DC;" />
                                 </MenuItem.Header>


### PR DESCRIPTION
Fixes #648 

The FontFamily being used was Segoe Fluent Icons, which is not supported inherently by Windows 10. Updated it to include the common resource `SymbolThemeFontFamily` that supports Segoe MDL2 Assets which is equivalent to Segoe Fluent Icons in Windows 10 with this regards.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/657)