### PR TITLE
Re-enabled commented out VSBuild tasks in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,27 +98,27 @@ stages:
        inputs:
         restoreSolution: '$(wpfgallerysolution)'
 
-    #  - task: VSBuild@1
-    #    continueOnError: true
-    #    displayName: 'Build .NET Core Samples using VSBuild'
-    #    inputs:
-    #     vsVersion: latest
-    #     solution: '$(solution)'
-    #     platform: '$(_Platform)'
-    #     msbuildArchitecture: '$(_ToolPlatform)'
-    #     configuration: '$(_Configuration)'
-    #     msbuildArgs: /m /bl:"$(Build.ArtifactStagingDirectory)\vsbuild\vsbuild.$(_Configuration).$(_Platform).$(_TargetFramework).binlog" /p:LangVersion=$(LangVersion)
+     - task: VSBuild@1
+       continueOnError: true
+       displayName: 'Build .NET Core Samples using VSBuild'
+       inputs:
+        vsVersion: latest
+        solution: '$(solution)'
+        platform: '$(_Platform)'
+        msbuildArchitecture: '$(_ToolPlatform)'
+        configuration: '$(_Configuration)'
+        msbuildArgs: /m /bl:"$(Build.ArtifactStagingDirectory)\vsbuild\vsbuild.$(_Configuration).$(_Platform).$(_TargetFramework).binlog" /p:LangVersion=$(LangVersion)
 
-    #  - task: VSBuild@1
-    #    continueOnError: true
-    #    displayName: 'Build MSBuild-only.NET Core Samples using VSBuild'
-    #    inputs:
-    #     vsVersion: latest
-    #     solution: '$(msbuildonlysolution)'
-    #     platform: '$(_Platform)'
-    #     msbuildArchitecture: '$(_ToolPlatform)'
-    #     configuration: '$(_Configuration)'
-    #     msbuildArgs: /m /bl:"$(Build.ArtifactStagingDirectory)\vsbuild\msbuild.vsbuild.$(_Configuration).$(_Platform).$(_TargetFramework).binlog" /p:LangVersion=$(LangVersion)
+     - task: VSBuild@1
+       continueOnError: true
+       displayName: 'Build MSBuild-only.NET Core Samples using VSBuild'
+       inputs:
+        vsVersion: latest
+        solution: '$(msbuildonlysolution)'
+        platform: '$(_Platform)'
+        msbuildArchitecture: '$(_ToolPlatform)'
+        configuration: '$(_Configuration)'
+        msbuildArgs: /m /bl:"$(Build.ArtifactStagingDirectory)\vsbuild\msbuild.vsbuild.$(_Configuration).$(_Platform).$(_TargetFramework).binlog" /p:LangVersion=$(LangVersion)
 
      - task: VSBuild@1
        continueOnError: true
@@ -161,7 +161,7 @@ stages:
 
      - task: DotNetCoreCLI@2
        continueOnError: true
-       displayName: 'Restore .NET Core Samples using dotnet.exe'
+       displayName: 'Restore WPF Gallery using dotnet.exe'
        inputs:
         command: 'restore'
         configuration: $(_Configuration)


### PR DESCRIPTION
During CodeQL testing, we disabled some extra VSBuild  tasks in azure-pipeline.yml. Re-enabling those tasks.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/658)