### PR TITLE
Fixed navigation in NavigationCard due to missing binding

### DIFF
--- a/Sample Applications/WPFGallery/Resources/Templates.xaml
+++ b/Sample Applications/WPFGallery/Resources/Templates.xaml
@@ -18,7 +18,7 @@
             HorizontalContentAlignment="Left"
             AutomationProperties.Name="{Binding Title, StringFormat='{}{0}Page'}"
             Command="{Binding ViewModel.NavigateCommand, RelativeSource={RelativeSource AncestorType={x:Type Page}}}"
-            CommandParameter="{Binding}">
+            CommandParameter="{Binding PageType}">
             <StackPanel Orientation="Horizontal">
                 <Image Source="{Binding ImageSource}"
                         Width="50"


### PR DESCRIPTION
### Description

While resolving merge conflicts for some PRs binding to the PageType in NavigationCardTemplate got removed, resulting in none of the navigation cards to work.

In this PR, I have added the binding to fix the above issue.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/668)