### PR TITLE
Fixed WPF Gallery in Windows 10 and TitleBar buttons

### DIFF
--- a/Sample Applications/WPFGallery/Helpers/Utility.cs
+++ b/Sample Applications/WPFGallery/Helpers/Utility.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WPFGallery.Helpers
+{
+    internal static class Utility
+    {
+        public static bool IsBackdropSupported()
+        {
+            var os = Environment.OSVersion;
+            var version = os.Version;
+
+            if (version.Major >= 10 && version.Build >= 22621)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        public static bool IsBackdropDisabled()
+        {
+            var appContextBackdropData = AppContext.GetData("Switch.System.Windows.Appearance.DisableFluentThemeWindowBackdrop");
+            bool disableFluentThemeWindowBackdrop = false;
+
+            if (appContextBackdropData != null)
+            {
+                disableFluentThemeWindowBackdrop = bool.Parse(Convert.ToString(appContextBackdropData));
+            }
+
+            return disableFluentThemeWindowBackdrop;
+        }
+    }
+}

--- a/Sample Applications/WPFGallery/Helpers/Utility.cs
+++ b/Sample Applications/WPFGallery/Helpers/Utility.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace WPFGallery.Helpers
+﻿namespace WPFGallery.Helpers
 {
     internal static class Utility
     {
@@ -13,11 +7,7 @@ namespace WPFGallery.Helpers
             var os = Environment.OSVersion;
             var version = os.Version;
 
-            if (version.Major >= 10 && version.Build >= 22621)
-            {
-                return true;
-            }
-            return false;
+            return version.Major >= 10 && version.Build >= 22621;
         }
 
         public static bool IsBackdropDisabled()

--- a/Sample Applications/WPFGallery/MainWindow.xaml
+++ b/Sample Applications/WPFGallery/MainWindow.xaml
@@ -48,6 +48,14 @@
                 <Trigger Property="IsMouseOver" Value="True">
                     <Setter Property="Background" Value="{DynamicResource ControlAltFillColorQuarternaryBrush}" />
                 </Trigger>
+                <MultiDataTrigger>
+                    <MultiDataTrigger.Conditions>
+                        <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True" />
+                        <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Mode=Self}}" Value="True" />
+                    </MultiDataTrigger.Conditions>
+                    <Setter Property="Background" Value="{DynamicResource SystemColorHighlightColorBrush}" />
+                    <Setter Property="Foreground" Value="{DynamicResource SystemColorHighlightTextColorBrush}" />
+                </MultiDataTrigger>
             </Style.Triggers>
         </Style>
 
@@ -57,6 +65,14 @@
                     <Setter Property="Background" Value="#C42B1C" />
                     <Setter Property="Foreground" Value="White" />
                 </Trigger>
+                <MultiDataTrigger>
+                    <MultiDataTrigger.Conditions>
+                        <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True" />
+                        <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Mode=Self}}" Value="True" />
+                    </MultiDataTrigger.Conditions>
+                    <Setter Property="Background" Value="{DynamicResource SystemColorHighlightColorBrush}" />
+                    <Setter Property="Foreground" Value="{DynamicResource SystemColorHighlightTextColorBrush}" />
+                </MultiDataTrigger>
             </Style.Triggers>
         </Style>
     </Window.Resources>

--- a/Sample Applications/WPFGallery/MainWindow.xaml
+++ b/Sample Applications/WPFGallery/MainWindow.xaml
@@ -18,10 +18,14 @@
     <Window.Resources>
         <helpers:EmptyToVisibilityConverter x:Key="EmptyToVisibilityConverter" />
 
-
         <Style x:Key="TitleBarDefaultButtonStyle" TargetType="Button">
             <Setter Property="MinWidth" Value="48" />
             <Setter Property="MinHeight" Value="32" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="WindowChrome.IsHitTestVisibleInChrome" Value="True" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">
@@ -37,43 +41,23 @@
                                 RecognizesAccessKey="True"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
-                        <ControlTemplate.Triggers>
-                            <Trigger Property="IsMouseOver" Value="true">
-                                <Setter TargetName="EnclosingBorder" Property="Background" Value="#E5EAEF" />
-                            </Trigger>
-                        </ControlTemplate.Triggers>
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource ControlAltFillColorQuarternaryBrush}" />
+                </Trigger>
+            </Style.Triggers>
         </Style>
 
-        <Style x:Key="TitleBarDefaultCloseButtonStyle" TargetType="Button">
-            <Setter Property="MinWidth" Value="48" />
-            <Setter Property="MinHeight" Value="32" />
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="Button">
-                        <Border
-                            x:Name="EnclosingBorder"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            SnapsToDevicePixels="True">
-                            <ContentPresenter
-                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                RecognizesAccessKey="True"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </Border>
-                        <ControlTemplate.Triggers>
-                            <Trigger Property="IsMouseOver" Value="true">
-                                <Setter TargetName="EnclosingBorder" Property="Background" Value="#C42B1C" />
-                                <Setter Property="Foreground" Value="White" />
-                            </Trigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
+        <Style x:Key="TitleBarDefaultCloseButtonStyle" BasedOn="{StaticResource TitleBarDefaultButtonStyle}" TargetType="Button">
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#C42B1C" />
+                    <Setter Property="Foreground" Value="White" />
+                </Trigger>
+            </Style.Triggers>
         </Style>
     </Window.Resources>
     <Grid x:Name="MainGrid">
@@ -149,45 +133,33 @@
             <Button
                 x:Name="MinimizeButton"
                 Grid.Column="2"
-                VerticalAlignment="Top"
-                Background="Transparent"
-                BorderBrush="Transparent"
                 Click="MinimizeWindow"
-                Style="{StaticResource TitleBarDefaultButtonStyle}"
-                WindowChrome.IsHitTestVisibleInChrome="True">
+                Style="{StaticResource TitleBarDefaultButtonStyle}">
                 <TextBlock
                     VerticalAlignment="Center"
                     FontFamily="{StaticResource SymbolThemeFontFamily}"
-                    FontSize="12"
+                    FontSize="10"
                     Text="&#xE921;" />
             </Button>
 
             <Button
                 x:Name="MaximizeButton"
                 Grid.Column="3"
-                VerticalAlignment="Top"
-                Background="Transparent"
-                BorderBrush="Transparent"
                 Click="MaximizeWindow"
-                Style="{StaticResource TitleBarDefaultButtonStyle}"
-                WindowChrome.IsHitTestVisibleInChrome="True">
+                Style="{StaticResource TitleBarDefaultButtonStyle}">
                 <TextBlock
                     x:Name="MaximizeIcon"
                     VerticalAlignment="Center"
                     FontFamily="{StaticResource SymbolThemeFontFamily}"
-                    FontSize="12"
+                    FontSize="10"
                     Text="&#xE922;" />
             </Button>
 
             <Button
                 x:Name="CloseButton"
                 Grid.Column="4"
-                VerticalAlignment="Top"
-                Background="Transparent"
-                BorderBrush="Transparent"
                 Click="CloseWindow"
-                Style="{StaticResource TitleBarDefaultCloseButtonStyle}"
-                WindowChrome.IsHitTestVisibleInChrome="True">
+                Style="{StaticResource TitleBarDefaultCloseButtonStyle}">
                 <TextBlock
                     VerticalAlignment="Center"
                     FontFamily="{StaticResource SymbolThemeFontFamily}"

--- a/Sample Applications/WPFGallery/MainWindow.xaml.cs
+++ b/Sample Applications/WPFGallery/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Automation.Peers;
 using System.Windows.Automation;
 using WPFGallery.Controls;
 using System.Windows.Controls.Primitives;
+using WPFGallery.Helpers;
 
 namespace WPFGallery;
 
@@ -26,7 +27,8 @@ public partial class MainWindow : Window
         DataContext = this;
         InitializeComponent();
 
-        Toggle_TitleButtonVisibility();
+        UpdateWindowBackground();
+        UpdateTitleBarButtonsVisibility();
 
         _navigationService = navigationService;
         _navigationService.Navigating += OnNavigating;
@@ -49,26 +51,24 @@ public partial class MainWindow : Window
         this.StateChanged += MainWindow_StateChanged;
     }
 
+    private void UpdateWindowBackground()
+    {
+        if((!Utility.IsBackdropDisabled() && 
+                    !Utility.IsBackdropSupported()))
+        {
+            this.SetResourceReference(BackgroundProperty, "WindowBackground");
+        }
+    }
+
     private void SystemEvents_UserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
     {
         Dispatcher.Invoke(() =>
         {
-            if (SystemParameters.HighContrast)
-            {
-                MinimizeButton.Visibility = Visibility.Visible;
-                MaximizeButton.Visibility = Visibility.Visible;
-                CloseButton.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                MinimizeButton.Visibility = Visibility.Collapsed;
-                MaximizeButton.Visibility = Visibility.Collapsed;
-                CloseButton.Visibility = Visibility.Collapsed;
-            }
+            UpdateTitleBarButtonsVisibility();
         });
     }
 
-    private void MainWindow_StateChanged(object sender, EventArgs e)
+    private void MainWindow_StateChanged(object? sender, EventArgs e)
     {
         if (this.WindowState == WindowState.Maximized)
         {
@@ -98,39 +98,20 @@ public partial class MainWindow : Window
         }
     }
 
-    private void Toggle_TitleButtonVisibility()
+    private void UpdateTitleBarButtonsVisibility()
     {
-        var appContextBackdropData = AppContext.GetData("Switch.System.Windows.Appearance.DisableFluentThemeWindowBackdrop");
-        bool disableFluentThemeWindowBackdrop = false;
-
-        if (appContextBackdropData != null)
+        if (Utility.IsBackdropDisabled() || !Utility.IsBackdropSupported() ||
+                SystemParameters.HighContrast == true)
         {
-            disableFluentThemeWindowBackdrop = bool.Parse(Convert.ToString(appContextBackdropData));
+            MinimizeButton.Visibility = Visibility.Visible;
+            MaximizeButton.Visibility = Visibility.Visible;
+            CloseButton.Visibility = Visibility.Visible;
         }
-
-
-        if (!disableFluentThemeWindowBackdrop)
+        else
         {
-            foreach (ResourceDictionary mergedDictionary in Application.Current.Resources.MergedDictionaries)
-            {
-                if(Application.Current.ThemeMode != ThemeMode.None)
-                {
-                    if (SystemParameters.HighContrast == true)
-                    {
-                        MinimizeButton.Visibility = Visibility.Visible;
-                        MaximizeButton.Visibility = Visibility.Visible;
-                        CloseButton.Visibility = Visibility.Visible;
-                    }
-                    else
-                    {
-                        MinimizeButton.Visibility = Visibility.Collapsed;
-                        MaximizeButton.Visibility = Visibility.Collapsed;
-                        CloseButton.Visibility = Visibility.Collapsed;
-                    }
-
-                    break;
-                }
-            }
+            MinimizeButton.Visibility = Visibility.Collapsed;
+            MaximizeButton.Visibility = Visibility.Collapsed;
+            CloseButton.Visibility = Visibility.Collapsed;
         }
     }
 

--- a/Sample Applications/WPFGallery/WPFGallery.csproj
+++ b/Sample Applications/WPFGallery/WPFGallery.csproj
@@ -27,10 +27,6 @@
 		<Resource Include="Assets\win11-dashboard.light.png" />
 		<Resource Include="Assets\UserDashboard\*" />
 	</ItemGroup>
-
-  <ItemGroup>
-    <RuntimeHostConfigurationOption Include="Switch.System.Windows.Appearance.DisableFluentThemeWindowBackdrop" Value="True" />
-  </ItemGroup>
 	
 	<PropertyGroup>
 		<ApplicationIcon>Assets\WPFGalleryPreviewIcon.ico</ApplicationIcon>

--- a/Sample Applications/WPFGallery/WPFGallery.csproj
+++ b/Sample Applications/WPFGallery/WPFGallery.csproj
@@ -27,6 +27,10 @@
 		<Resource Include="Assets\win11-dashboard.light.png" />
 		<Resource Include="Assets\UserDashboard\*" />
 	</ItemGroup>
+
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="Switch.System.Windows.Appearance.DisableFluentThemeWindowBackdrop" Value="True" />
+  </ItemGroup>
 	
 	<PropertyGroup>
 		<ApplicationIcon>Assets\WPFGalleryPreviewIcon.ico</ApplicationIcon>


### PR DESCRIPTION
### Description

There were a couple of issues in the TitleBar buttons :
- They were not visible in Dark theme, moreover hovering over them, the button's went white.
- Reduces redundancy in TitleBar button styles
- WPF Gallery was not appearing correctly in Windows 10, due to some issues in the latest WPF code, added a workaround for that by checking if Backdrop is supported on the machine. ( Thanks @harshit7962 for bringing this up )
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/671)