### PR TITLE
Fix WPF Gallery crash on UserItem deletion in UserDashboard.

### DIFF
--- a/Sample Applications/WPFGallery/ViewModels/Samples/UserDashboardPageViewModel.cs
+++ b/Sample Applications/WPFGallery/ViewModels/Samples/UserDashboardPageViewModel.cs
@@ -58,9 +58,17 @@ namespace WPFGallery.ViewModels.Samples
 
                 Task.Delay(2000).ContinueWith(_ => IsDeleted = false, TaskScheduler.FromCurrentSynchronizationContext());
                 int index = Users.IndexOf(user);
-                
-                SelectedUser = Users[index+1];
+
                 Users.Remove(user);
+                if (index == Users.Count)
+                {
+                    SelectedUser = Users.Count > 0 ? Users[index - 1] : null;
+                }
+                else
+                {
+                    SelectedUser = Users[index];
+                }
+
                 IsRead = true;
                 IsEditing = false;
 


### PR DESCRIPTION
Fixed the index out of range issue in WPF Gallery when deleting the last UserItem in UserDashboard.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/674)