### PR TITLE
Add samplemedia and sampleresources to Brush.csproj to Fix Rendering …

### DIFF
--- a/Graphics/Brushes/Brushes.csproj
+++ b/Graphics/Brushes/Brushes.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
@@ -133,5 +133,11 @@
     <Content Include="sampleimages\*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+	  <Content Include="samplemedia\xbox.wmv">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="sampleresources\toc.xml">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds the necessary references to existing folders to the Brush.csproj file to address an issue where brushes were not rendering correctly during .NET 10 Validation Sample Apps. By including these resources, the rendering of brushes is expected to function as intended.