### PR TITLE
Fixed WPF Gallery for HC mode

### DIFF
--- a/Sample Applications/WPFGallery/Controls/HeaderTile.xaml.cs
+++ b/Sample Applications/WPFGallery/Controls/HeaderTile.xaml.cs
@@ -1,4 +1,6 @@
 ﻿
+using Microsoft.Win32;
+
 namespace WPFGallery.Controls
 {
     /// <summary>
@@ -10,12 +12,15 @@ namespace WPFGallery.Controls
         {
             InitializeComponent();
             UpdateButtonResources();
-            SystemParameters.StaticPropertyChanged += SystemParameters_StaticPropertyChanged;
+            SystemEvents.UserPreferenceChanged += SystemEvents_UserPreferenceChanged;
         }
 
-        private void SystemParameters_StaticPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void SystemEvents_UserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
         {
-            UpdateButtonResources();
+            Dispatcher.Invoke(() =>
+            {
+                UpdateButtonResources();
+            });
         }
 
         private void UpdateButtonResources()

--- a/Sample Applications/WPFGallery/Controls/HeaderTile.xaml.cs
+++ b/Sample Applications/WPFGallery/Controls/HeaderTile.xaml.cs
@@ -9,6 +9,31 @@ namespace WPFGallery.Controls
         public HeaderTile()
         {
             InitializeComponent();
+            UpdateButtonResources();
+            SystemParameters.StaticPropertyChanged += SystemParameters_StaticPropertyChanged;
+        }
+
+        private void SystemParameters_StaticPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            UpdateButtonResources();
+        }
+
+        private void UpdateButtonResources()
+        {
+            if (!SystemParameters.HighContrast)
+            {
+                Color? color = (Color)Application.Current!.FindResource("AcrylicBackgroundFillColorDefault");
+
+                RootButton.Resources["ButtonBackground"] = new SolidColorBrush { Color = color ?? Colors.Gray, Opacity = 0.8 };
+                RootButton.Resources["ButtonBackgroundPointerOver"] = new SolidColorBrush { Color = color ?? Colors.Gray, Opacity = 0.9 };
+                RootButton.Resources["ButtonBackgroundPressed"] = new SolidColorBrush { Color = color ?? Colors.Gray, Opacity = 1.0 };
+            }
+            else
+            {
+                RootButton.Resources["ButtonBackground"] = SystemColors.ControlBrush;
+                RootButton.Resources["ButtonBackgroundPointerOver"] = SystemColors.ControlBrush;
+                RootButton.Resources["ButtonBackgroundPressed"] = SystemColors.ControlBrush;
+            }
         }
 
         public string Title

--- a/Sample Applications/WPFGallery/Controls/TileGallery.xaml
+++ b/Sample Applications/WPFGallery/Controls/TileGallery.xaml
@@ -7,10 +7,6 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
-        <SolidColorBrush x:Key="ButtonBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
-        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
-        <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
-
         <Style x:Key="TileGalleryScrollButtonStyle" BasedOn="{StaticResource DefaultButtonStyle}" TargetType="Button">
             <Setter Property="Border.CornerRadius" Value="4" />
             <Setter Property="Width" Value="16" />

--- a/Sample Applications/WPFGallery/MainWindow.xaml
+++ b/Sample Applications/WPFGallery/MainWindow.xaml
@@ -76,197 +76,199 @@
             </Style.Triggers>
         </Style>
     </Window.Resources>
-    <Grid x:Name="MainGrid">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="44" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
+    <Border x:Name="HighContrastBorder" BorderBrush="Transparent" BorderThickness="8 2 8 8">
+        <Grid x:Name="MainGrid">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="44" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
-        <Grid
-            Grid.Row="0"
-            Grid.ColumnSpan="2"
-            Height="44">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
+            <Grid
+                Grid.Row="0"
+                Grid.ColumnSpan="2"
+                Height="44">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
 
-            <Button
-                x:Name="BackButton"
-                Grid.Column="0"
-                Height="32"
-                Width="40"
-                Margin="4,0"
-                VerticalAlignment="Center"
-                AutomationProperties.Name="Back"
-                Background="Transparent"
-                BorderBrush="Transparent"
-                Command="{Binding ViewModel.BackCommand}"
-                IsEnabled="{Binding ViewModel.CanNavigateback}"
-                WindowChrome.IsHitTestVisibleInChrome="True"
-                ToolTipService.ToolTip="Back">
-                <Button.Resources>
-                    <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="Transparent" />
-                    <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Transparent" />
-                </Button.Resources>
-                <TextBlock
+                <Button
+                    x:Name="BackButton"
+                    Grid.Column="0"
+                    Height="32"
+                    Width="40"
+                    Margin="4,0"
                     VerticalAlignment="Center"
-                    FontFamily="{StaticResource SymbolThemeFontFamily}"
-                    FontSize="12"
-                    Text="&#xE72B;">
-                    <TextBlock.Style>
-                        <Style TargetType="TextBlock">
-                            <Style.Triggers>
-                                <Trigger Property="IsEnabled" Value="False">
-                                    <Setter Property="Foreground" Value="{DynamicResource TextFillColorDisabledBrush}">
-                                    </Setter>
-                                </Trigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBlock.Style>
-                </TextBlock>
-            </Button>
+                    AutomationProperties.Name="Back"
+                    Background="Transparent"
+                    BorderBrush="Transparent"
+                    Command="{Binding ViewModel.BackCommand}"
+                    IsEnabled="{Binding ViewModel.CanNavigateback}"
+                    WindowChrome.IsHitTestVisibleInChrome="True"
+                    ToolTipService.ToolTip="Back">
+                    <Button.Resources>
+                        <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="Transparent" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Transparent" />
+                    </Button.Resources>
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        FontFamily="{StaticResource SymbolThemeFontFamily}"
+                        FontSize="12"
+                        Text="&#xE72B;">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Style.Triggers>
+                                    <Trigger Property="IsEnabled" Value="False">
+                                        <Setter Property="Foreground" Value="{DynamicResource TextFillColorDisabledBrush}">
+                                        </Setter>
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Button>
 
-            <StackPanel
-                Grid.Column="1"
-                Margin="4,0,0,0"
-                Orientation="Horizontal">
-                <Image
-                    Width="20"
-                    VerticalAlignment="Center"
-                    Source="pack://application:,,,/Assets/WPFGalleryPreviewIcon.png" />
-                <TextBlock
-                    Margin="16,0,0,0"
-                    VerticalAlignment="Center"
-                    Style="{StaticResource CaptionTextBlockStyle}"
-                    AutomationProperties.HeadingLevel="Level1"
-                    Text="WPF Gallery Preview" />
-            </StackPanel>
+                <StackPanel
+                    Grid.Column="1"
+                    Margin="4,0,0,0"
+                    Orientation="Horizontal">
+                    <Image
+                        Width="20"
+                        VerticalAlignment="Center"
+                        Source="pack://application:,,,/Assets/WPFGalleryPreviewIcon.png" />
+                    <TextBlock
+                        Margin="16,0,0,0"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        AutomationProperties.HeadingLevel="Level1"
+                        Text="WPF Gallery Preview" />
+                </StackPanel>
 
-            <Button
-                x:Name="MinimizeButton"
-                Grid.Column="2"
-                Click="MinimizeWindow"
-                Style="{StaticResource TitleBarDefaultButtonStyle}">
-                <TextBlock
-                    VerticalAlignment="Center"
-                    FontFamily="{StaticResource SymbolThemeFontFamily}"
-                    FontSize="10"
-                    Text="&#xE921;" />
-            </Button>
+                <Button
+                    x:Name="MinimizeButton"
+                    Grid.Column="2"
+                    Click="MinimizeWindow"
+                    Style="{StaticResource TitleBarDefaultButtonStyle}">
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        FontFamily="{StaticResource SymbolThemeFontFamily}"
+                        FontSize="10"
+                        Text="&#xE921;" />
+                </Button>
 
-            <Button
-                x:Name="MaximizeButton"
-                Grid.Column="3"
-                Click="MaximizeWindow"
-                Style="{StaticResource TitleBarDefaultButtonStyle}">
-                <TextBlock
-                    x:Name="MaximizeIcon"
-                    VerticalAlignment="Center"
-                    FontFamily="{StaticResource SymbolThemeFontFamily}"
-                    FontSize="10"
-                    Text="&#xE922;" />
-            </Button>
+                <Button
+                    x:Name="MaximizeButton"
+                    Grid.Column="3"
+                    Click="MaximizeWindow"
+                    Style="{StaticResource TitleBarDefaultButtonStyle}">
+                    <TextBlock
+                        x:Name="MaximizeIcon"
+                        VerticalAlignment="Center"
+                        FontFamily="{StaticResource SymbolThemeFontFamily}"
+                        FontSize="10"
+                        Text="&#xE922;" />
+                </Button>
 
-            <Button
-                x:Name="CloseButton"
-                Grid.Column="4"
-                Click="CloseWindow"
-                Style="{StaticResource TitleBarDefaultCloseButtonStyle}">
-                <TextBlock
-                    VerticalAlignment="Center"
-                    FontFamily="{StaticResource SymbolThemeFontFamily}"
-                    FontSize="16"
-                    Text="&#xE711;" />
-            </Button>
-        </Grid>
+                <Button
+                    x:Name="CloseButton"
+                    Grid.Column="4"
+                    Click="CloseWindow"
+                    Style="{StaticResource TitleBarDefaultCloseButtonStyle}">
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        FontFamily="{StaticResource SymbolThemeFontFamily}"
+                        FontSize="16"
+                        Text="&#xE711;" />
+                </Button>
+            </Grid>
 
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid Grid.Column="0">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
+            <Grid Grid.Row="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid Grid.Column="0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
 
-                <!--<TextBox
-                    x:Name="SearchBox"
-                    Width="250"
-                    Margin="10"
-                    AutomationProperties.Name="Search"
-                    KeyUp="SearchBox_KeyUp"
-                    LostFocus="SearchBox_LostFocus" />-->
-
-
-                <TreeView
-                    x:Name="ControlsList"
-                    Grid.Row="1"
-                    Margin="8,8,0,0"
-                    AutomationProperties.Name="Navigation Pane"
-                    ItemsSource="{Binding ViewModel.Controls}"
-                    PreviewKeyDown="ControlsList_PreviewKeyDown"
-                    PreviewMouseLeftButtonUp="ControlsList_PreviewMouseLeftButtonUp"
-                    Loaded="ControlsList_Loaded">
-                    <TreeView.ItemTemplate>
-                        <HierarchicalDataTemplate ItemsSource="{Binding Items}">
-                            <Grid MinHeight="30">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="16" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock
-                                    MaxWidth="16"
-                                    VerticalAlignment="Center"
-                                    AutomationProperties.Name="{Binding Title, StringFormat='{}{0} Page'}"
-                                    Focusable="False"
-                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                    FontSize="16"
-                                    Text="{Binding IconGlyph}"
-                                    Visibility="{Binding IconGlyph, Converter={StaticResource EmptyToVisibilityConverter}}" />
-                                <TextBlock
-                                    Grid.Column="2"
-                                    VerticalAlignment="Center"
-                                    Text="{Binding Title}" />
-                            </Grid>
-                        </HierarchicalDataTemplate>
-                    </TreeView.ItemTemplate>
-                </TreeView>
-
-                <DockPanel Grid.Row="2">
-                    <Button
-                        x:Name="SettingsButton"
+                    <!--<TextBox
+                        x:Name="SearchBox"
                         Width="250"
                         Margin="10"
-                        HorizontalContentAlignment="Left"
-                        AutomationProperties.Name="Settings"
-                        Command="{Binding ViewModel.SettingsCommand}"
-                        Click="SettingsButton_Click"
-                        DockPanel.Dock="Bottom">
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock x:Name="SettingsIcon" Margin="0,4,0,0" FontFamily="{StaticResource SymbolThemeFontFamily}">&#xE713;</TextBlock>
-                            <TextBlock Margin="8,0,0,0" Text="Settings" />
-                        </StackPanel>
-                    </Button>
-                </DockPanel>
+                        AutomationProperties.Name="Search"
+                        KeyUp="SearchBox_KeyUp"
+                        LostFocus="SearchBox_LostFocus" />-->
+
+
+                    <TreeView
+                        x:Name="ControlsList"
+                        Grid.Row="1"
+                        Margin="8,8,0,0"
+                        AutomationProperties.Name="Navigation Pane"
+                        ItemsSource="{Binding ViewModel.Controls}"
+                        PreviewKeyDown="ControlsList_PreviewKeyDown"
+                        PreviewMouseLeftButtonUp="ControlsList_PreviewMouseLeftButtonUp"
+                        Loaded="ControlsList_Loaded">
+                        <TreeView.ItemTemplate>
+                            <HierarchicalDataTemplate ItemsSource="{Binding Items}">
+                                <Grid MinHeight="30">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="16" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock
+                                        MaxWidth="16"
+                                        VerticalAlignment="Center"
+                                        AutomationProperties.Name="{Binding Title, StringFormat='{}{0} Page'}"
+                                        Focusable="False"
+                                        FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                        FontSize="16"
+                                        Text="{Binding IconGlyph}"
+                                        Visibility="{Binding IconGlyph, Converter={StaticResource EmptyToVisibilityConverter}}" />
+                                    <TextBlock
+                                        Grid.Column="2"
+                                        VerticalAlignment="Center"
+                                        Text="{Binding Title}" />
+                                </Grid>
+                            </HierarchicalDataTemplate>
+                        </TreeView.ItemTemplate>
+                    </TreeView>
+
+                    <DockPanel Grid.Row="2">
+                        <Button
+                            x:Name="SettingsButton"
+                            Width="250"
+                            Margin="10"
+                            HorizontalContentAlignment="Left"
+                            AutomationProperties.Name="Settings"
+                            Command="{Binding ViewModel.SettingsCommand}"
+                            Click="SettingsButton_Click"
+                            DockPanel.Dock="Bottom">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock x:Name="SettingsIcon" Margin="0,4,0,0" FontFamily="{StaticResource SymbolThemeFontFamily}">&#xE713;</TextBlock>
+                                <TextBlock Margin="8,0,0,0" Text="Settings" />
+                            </StackPanel>
+                        </Button>
+                    </DockPanel>
+                </Grid>
+                <Border
+                    Grid.Column="1"
+                    Margin="4,0,0,0"
+                    Padding="24,16,24,0"
+                    Background="{DynamicResource LayerFillColorDefaultBrush}"
+                    BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8,0,0,0">
+                    <Frame x:Name="RootContentFrame" Navigated="RootContentFrame_Navigated"/>
+                </Border>
             </Grid>
-            <Border
-                Grid.Column="1"
-                Margin="4,0,0,0"
-                Padding="24,16,24,0"
-                Background="{DynamicResource LayerFillColorDefaultBrush}"
-                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="8,0,0,0">
-                <Frame x:Name="RootContentFrame" Navigated="RootContentFrame_Navigated"/>
-            </Border>
         </Grid>
-    </Grid>
+    </Border>
 </Window>

--- a/Sample Applications/WPFGallery/MainWindow.xaml.cs
+++ b/Sample Applications/WPFGallery/MainWindow.xaml.cs
@@ -47,14 +47,8 @@ public partial class MainWindow : Window
             }
         );
 
-        //SystemEvents.UserPreferenceChanged += SystemEvents_UserPreferenceChanged;
-        SystemParameters.StaticPropertyChanged += SystemParameters_StaticPropertyChanged;
+        SystemEvents.UserPreferenceChanged += SystemEvents_UserPreferenceChanged;
         this.StateChanged += MainWindow_StateChanged;
-    }
-
-    private void SystemParameters_StaticPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
-    {
-        UpdateTitleBarButtonsVisibility();
     }
 
     private void UpdateWindowBackground()

--- a/Sample Applications/WPFGallery/MainWindow.xaml.cs
+++ b/Sample Applications/WPFGallery/MainWindow.xaml.cs
@@ -47,8 +47,14 @@ public partial class MainWindow : Window
             }
         );
 
-        SystemEvents.UserPreferenceChanged += SystemEvents_UserPreferenceChanged;
+        //SystemEvents.UserPreferenceChanged += SystemEvents_UserPreferenceChanged;
+        SystemParameters.StaticPropertyChanged += SystemParameters_StaticPropertyChanged;
         this.StateChanged += MainWindow_StateChanged;
+    }
+
+    private void SystemParameters_StaticPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        UpdateTitleBarButtonsVisibility();
     }
 
     private void UpdateWindowBackground()
@@ -106,12 +112,26 @@ public partial class MainWindow : Window
             MinimizeButton.Visibility = Visibility.Visible;
             MaximizeButton.Visibility = Visibility.Visible;
             CloseButton.Visibility = Visibility.Visible;
+
+            if(SystemParameters.HighContrast == true)
+            {
+                HighContrastBorder.SetResourceReference(BorderBrushProperty, SystemColors.ActiveCaptionBrushKey);
+                HighContrastBorder.BorderThickness = new Thickness(8, 2, 8, 8);
+            }
+            else
+            {
+                HighContrastBorder.BorderBrush = Brushes.Transparent;
+                HighContrastBorder.BorderThickness = new Thickness(0);
+            }
         }
         else
         {
             MinimizeButton.Visibility = Visibility.Collapsed;
             MaximizeButton.Visibility = Visibility.Collapsed;
             CloseButton.Visibility = Visibility.Collapsed;
+
+            HighContrastBorder.BorderThickness = new Thickness(0);
+            HighContrastBorder.BorderBrush = Brushes.Transparent;
         }
     }
 
@@ -231,4 +251,5 @@ public partial class MainWindow : Window
             }
         }
     }
+
 }

--- a/Sample Applications/WPFGallery/Views/AllSamplesPage.xaml
+++ b/Sample Applications/WPFGallery/Views/AllSamplesPage.xaml
@@ -23,7 +23,7 @@
 
         <ScrollViewer
             Grid.Row="1"
-            Margin="-13,0,0,0"
+            Margin="0"
             VerticalScrollBarVisibility="Auto">
             <ItemsControl
                 Grid.Row="1"

--- a/Sample Applications/WPFGallery/Views/DashboardPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DashboardPage.xaml
@@ -22,8 +22,7 @@
             </Grid.RowDefinitions>
 
             <Border CornerRadius="8,0,0,0" 
-                    Grid.RowSpan="2"
-                    Panel.ZIndex="1">
+                    Grid.RowSpan="2">
                 <Border.Background>
                     <ImageBrush ImageSource="pack://application:,,,/Assets/win11-dashboard.light.png" Stretch="UniformToFill" />
                 </Border.Background>
@@ -38,8 +37,7 @@
             <Border
                 Height="220"
                 BorderThickness="0,0,0,1"
-                CornerRadius="8,0,0,0"
-                Panel.ZIndex="1">
+                CornerRadius="8,0,0,0">
 
                 <StackPanel Margin="36,48,0,0" VerticalAlignment="Top" TextElement.Foreground="Black">
                     <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text=".NET 9" Margin="0,0,0,2" AutomationProperties.HeadingLevel="Level1" />
@@ -55,7 +53,7 @@
                 </StackPanel>
             </Border>
             
-            <controls:TileGallery Grid.Row="1" HorizontalAlignment="Stretch" Margin="0" Panel.ZIndex="2"/>
+            <controls:TileGallery Grid.Row="1" HorizontalAlignment="Stretch" Margin="0"/>
 
             <ItemsControl
                 Grid.Row="2"

--- a/Sample Applications/WPFGallery/Views/DashboardPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DashboardPage.xaml
@@ -10,8 +10,9 @@
     d:DesignHeight="450"
     d:DesignWidth="800"
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-    mc:Ignorable="d">
-    <ScrollViewer Margin="-24,-16,-24,12">
+    mc:Ignorable="d"
+    Margin="-24,-16,-24,12">
+    <ScrollViewer >
 
         <Grid>
             <Grid.RowDefinitions>
@@ -21,7 +22,8 @@
             </Grid.RowDefinitions>
 
             <Border CornerRadius="8,0,0,0" 
-                    Grid.RowSpan="2">
+                    Grid.RowSpan="2"
+                    Panel.ZIndex="1">
                 <Border.Background>
                     <ImageBrush ImageSource="pack://application:,,,/Assets/win11-dashboard.light.png" Stretch="UniformToFill" />
                 </Border.Background>
@@ -36,7 +38,8 @@
             <Border
                 Height="220"
                 BorderThickness="0,0,0,1"
-                CornerRadius="8,0,0,0">
+                CornerRadius="8,0,0,0"
+                Panel.ZIndex="1">
 
                 <StackPanel Margin="36,48,0,0" VerticalAlignment="Top" TextElement.Foreground="Black">
                     <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text=".NET 9" Margin="0,0,0,2" AutomationProperties.HeadingLevel="Level1" />
@@ -52,7 +55,7 @@
                 </StackPanel>
             </Border>
             
-            <controls:TileGallery Grid.Row="1" HorizontalAlignment="Stretch" Margin="0"/>
+            <controls:TileGallery Grid.Row="1" HorizontalAlignment="Stretch" Margin="0" Panel.ZIndex="2"/>
 
             <ItemsControl
                 Grid.Row="2"

--- a/Sample Applications/WPFGallery/Views/WhatsNewPage.xaml
+++ b/Sample Applications/WPFGallery/Views/WhatsNewPage.xaml
@@ -56,6 +56,13 @@
                         system accent colors and their variations.
                     </Run>
                 </TextBlock>
+
+                <TextBlock TextWrapping="Wrap" Margin="0 0 0 12">
+                    <Bold>NOTE : </Bold>
+                    <Run>
+                        In HighContrast mode, all the AccentColor brushes and colors have the same value, and we won't see a difference in the brushes.
+                    </Run>
+                </TextBlock>
                 
                 <controls:ControlExample
                     Margin="2 10"

--- a/Sample Applications/WPFGallery/WPFGallery.csproj
+++ b/Sample Applications/WPFGallery/WPFGallery.csproj
@@ -12,9 +12,6 @@
     <NoWarn>$(NoWarn);WPF0001</NoWarn>
 	</PropertyGroup>
 
-  <Import Project="E:\repos\dk-wpf\eng\wpf-debug.targets"/>
-
-
 	<ItemGroup>
 	  <ApplicationDefinition Remove="App.xaml" />
 	  <Page Include="App.xaml" />

--- a/Sample Applications/WPFGallery/WPFGallery.csproj
+++ b/Sample Applications/WPFGallery/WPFGallery.csproj
@@ -12,6 +12,8 @@
     <NoWarn>$(NoWarn);WPF0001</NoWarn>
 	</PropertyGroup>
 
+  <Import Project="E:\repos\dk-wpf\eng\wpf-debug.targets"/>
+
 
 	<ItemGroup>
 	  <ApplicationDefinition Remove="App.xaml" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "9.0.100-rc.2.24474.11",
+        "version": "9.0.200",
         "rollForward": "latestFeature"
     },
     "altsdk": {
@@ -8,6 +8,6 @@
         "net6.0-windows": "6.0.417",
         "net7.0-windows": "7.0.404",
         "net8.0-windows": "8.0.100",
-        "net9.0-windows": "9.0.100-rc.2.24474.11"
+        "net9.0-windows": "9.0.200"
     }
 }


### PR DESCRIPTION
### Description

Fixes #681 

When launching WPF Gallery in HC mode or if theme is switched to HC mode when WPF Gallery is running, the application crashes. In this PR , I have fixed that by updating the .NET 9 version in the global.json as the error originated from WPF, which was fixed in servicing releases of WPF.

Moreover, fixed the border of the application in HC mode, by adding a root border in MainWindow and switching it's border thickness when HC mode is enabled/disabled.

Similarly, the header tiles in WPF Gallery, did not render the correct colors in HC mode, fixed that by subscribing to SystemParameters.StaticPropertyChanged event, for checking when the HC mode is enabled\disabled. This allows us to switch the resources when the theme changes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/691)