### PR TITLE
Fixes selection issue in ControlExample sample code textbox

### DIFF
--- a/Sample Applications/WPFGallery/Controls/ControlExample.xaml
+++ b/Sample Applications/WPFGallery/Controls/ControlExample.xaml
@@ -98,8 +98,8 @@
                                         BorderThickness="0"
                                         IsReadOnly="True"
                                         Text="{TemplateBinding XamlCode}"
-                                        TextWrapping="Wrap" 
-                                        Focusable="False"/>
+                                        TextWrapping="Wrap"
+                                        KeyboardNavigation.IsTabStop="False"/>
                                 </StackPanel>
 
                                 <Border

--- a/Sample Applications/WPFGallery/Controls/ControlExample.xaml
+++ b/Sample Applications/WPFGallery/Controls/ControlExample.xaml
@@ -11,9 +11,12 @@
         <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
         <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="0" />
         <Setter Property="IsReadOnly" Value="True" />
         <Setter Property="TextWrapping" Value="Wrap" />
+        <Setter Property="KeyboardNavigation.IsTabStop" Value="False" />
     </Style>
      
     <Style TargetType="{x:Type controls:ControlExample}">
@@ -91,15 +94,8 @@
                                     </Grid>
                                     <TextBox
                                         Style="{StaticResource SelectionTextBox}"
-                                        Padding="0"
                                         AutomationProperties.Name="XAML Source Code"
-                                        Background="Transparent"
-                                        BorderBrush="Transparent"
-                                        BorderThickness="0"
-                                        IsReadOnly="True"
-                                        Text="{TemplateBinding XamlCode}"
-                                        TextWrapping="Wrap"
-                                        KeyboardNavigation.IsTabStop="False"/>
+                                        Text="{TemplateBinding XamlCode}"/>
                                 </StackPanel>
 
                                 <Border
@@ -126,12 +122,8 @@
                                         </Button>
                                     </Grid>
                                     <TextBox
-                                        Padding="0"
+                                        Style="{StaticResource SelectionTextBox}"
                                         AutomationProperties.Name="CSharp Source Code"
-                                        Background="Transparent"
-                                        BorderBrush="Transparent"
-                                        BorderThickness="0"
-                                        IsReadOnly="True"
                                         Text="{TemplateBinding CsharpCode}" />
                                 </StackPanel>
                             </StackPanel>


### PR DESCRIPTION
### Description

Fixes #692 

Since, Focusable for TextBox in ControlExample was set to False, there was no selection being shown or happening. In this PR, I have modified it KeyboardNavigation.TabStop = False, as we only wanted to disable the tab stop navigation originally.

Aditionally, fixed the text box for CSharpCode block as well, using the same style for both XAML and C# code blocks.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/693)