### PR TITLE
Added third party notices for files derived from WPF UI Gallery

### DIFF
--- a/Sample Applications/WPFGallery/Controls/ControlExample.xaml
+++ b/Sample Applications/WPFGallery/Controls/ControlExample.xaml
@@ -1,3 +1,9 @@
+<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
  
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/Sample Applications/WPFGallery/Models/Person.cs
+++ b/Sample Applications/WPFGallery/Models/Person.cs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
 
 namespace WPFGallery.Models;
 

--- a/Sample Applications/WPFGallery/Models/Product.cs
+++ b/Sample Applications/WPFGallery/Models/Product.cs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
 
 namespace WPFGallery.Models;
 

--- a/Sample Applications/WPFGallery/ViewModels/BasicInput/ButtonPageViewModel.cs
+++ b/Sample Applications/WPFGallery/ViewModels/BasicInput/ButtonPageViewModel.cs
@@ -1,4 +1,7 @@
-
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
 
 namespace WPFGallery.ViewModels;
 

--- a/Sample Applications/WPFGallery/ViewModels/BasicInput/CheckBoxPageViewModel.cs
+++ b/Sample Applications/WPFGallery/ViewModels/BasicInput/CheckBoxPageViewModel.cs
@@ -1,4 +1,8 @@
-﻿
+﻿// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
 namespace WPFGallery.ViewModels;
 
 public partial class CheckBoxPageViewModel : ObservableObject 

--- a/Sample Applications/WPFGallery/ViewModels/BasicInput/ComboBoxPageViewModel.cs
+++ b/Sample Applications/WPFGallery/ViewModels/BasicInput/ComboBoxPageViewModel.cs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
 
 namespace WPFGallery.ViewModels;
 

--- a/Sample Applications/WPFGallery/ViewModels/BasicInput/RadioButtonPageViewModel.cs
+++ b/Sample Applications/WPFGallery/ViewModels/BasicInput/RadioButtonPageViewModel.cs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
 
 namespace WPFGallery.ViewModels;
 

--- a/Sample Applications/WPFGallery/ViewModels/BasicInput/SliderPageViewModel.cs
+++ b/Sample Applications/WPFGallery/ViewModels/BasicInput/SliderPageViewModel.cs
@@ -1,4 +1,8 @@
-﻿
+﻿// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
 namespace WPFGallery.ViewModels;
 
 

--- a/Sample Applications/WPFGallery/ViewModels/Collections/DataGridPageViewModel.cs
+++ b/Sample Applications/WPFGallery/ViewModels/Collections/DataGridPageViewModel.cs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
 
 using WPFGallery.Models;
 

--- a/Sample Applications/WPFGallery/ViewModels/Collections/ListBoxPageViewModel.cs
+++ b/Sample Applications/WPFGallery/ViewModels/Collections/ListBoxPageViewModel.cs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
 
 namespace WPFGallery.ViewModels;
 

--- a/Sample Applications/WPFGallery/ViewModels/Collections/ListViewPageViewModel.cs
+++ b/Sample Applications/WPFGallery/ViewModels/Collections/ListViewPageViewModel.cs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
 
 using WPFGallery.Models;
 

--- a/Sample Applications/WPFGallery/Views/BasicInput/ButtonPage.xaml
+++ b/Sample Applications/WPFGallery/Views/BasicInput/ButtonPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.ButtonPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/BasicInput/CheckBoxPage.xaml
+++ b/Sample Applications/WPFGallery/Views/BasicInput/CheckBoxPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.CheckBoxPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/BasicInput/ComboBoxPage.xaml
+++ b/Sample Applications/WPFGallery/Views/BasicInput/ComboBoxPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.ComboBoxPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/BasicInput/RadioButtonPage.xaml
+++ b/Sample Applications/WPFGallery/Views/BasicInput/RadioButtonPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.RadioButtonPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/BasicInput/SliderPage.xaml
+++ b/Sample Applications/WPFGallery/Views/BasicInput/SliderPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.SliderPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/Collections/DataGridPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Collections/DataGridPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.DataGridPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/Collections/ListBoxPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Collections/ListBoxPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.ListBoxPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/Collections/ListViewPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Collections/ListViewPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.ListViewPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/Collections/TreeViewPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Collections/TreeViewPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.TreeViewPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/DateAndTime/CalendarPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DateAndTime/CalendarPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.CalendarPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/DateAndTime/DatePickerPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DateAndTime/DatePickerPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.DatePickerPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/Layout/ExpanderPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Layout/ExpanderPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.ExpanderPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/Media/CanvasPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Media/CanvasPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.CanvasPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/Media/ImagePage.xaml
+++ b/Sample Applications/WPFGallery/Views/Media/ImagePage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.ImagePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/Navigation/MenuPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Navigation/MenuPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.MenuPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/Navigation/TabControlPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Navigation/TabControlPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.TabControlPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/StatusAndInfo/ProgressBarPage.xaml
+++ b/Sample Applications/WPFGallery/Views/StatusAndInfo/ProgressBarPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.ProgressBarPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/StatusAndInfo/ToolTipPage.xaml
+++ b/Sample Applications/WPFGallery/Views/StatusAndInfo/ToolTipPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.ToolTipPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/Text/LabelPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Text/LabelPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.LabelPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/Text/PasswordBoxPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Text/PasswordBoxPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.PasswordBoxPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/Text/RichTextEditPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Text/RichTextEditPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.RichTextEditPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/Text/TextBlockPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Text/TextBlockPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.TextBlockPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Sample Applications/WPFGallery/Views/Text/TextBoxPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Text/TextBoxPage.xaml
@@ -1,4 +1,11 @@
-﻿<Page
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+-->
+
+<Page
     x:Class="WPFGallery.Views.TextBoxPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"


### PR DESCRIPTION
### Description

Fixes #688. 

Missed adding the headers to the source code files derived from WPF UI Gallery. This PR adds the headers to the derived files

/ cc : @pomianowski. Apologies for the oversight and delay on this.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/700)