### PR TITLE
Disables NavigationUI visibility of Frame

### DIFF
--- a/Sample Applications/WPFGallery/MainWindow.xaml
+++ b/Sample Applications/WPFGallery/MainWindow.xaml
@@ -266,7 +266,7 @@
                     BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1"
                     CornerRadius="8,0,0,0">
-                    <Frame x:Name="RootContentFrame" Navigated="RootContentFrame_Navigated"/>
+                    <Frame x:Name="RootContentFrame" Navigated="RootContentFrame_Navigated" NavigationUIVisibility="Hidden"/>
                 </Border>
             </Grid>
         </Grid>


### PR DESCRIPTION
The PR disables the NavigationUI visibility of the Frame in the WPF Gallery application.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/702)