### PR TITLE
Apply default style to BackButton to match other titlebar button style

### DIFF
--- a/Sample Applications/WPFGallery/MainWindow.xaml
+++ b/Sample Applications/WPFGallery/MainWindow.xaml
@@ -98,17 +98,13 @@
                 <Button
                     x:Name="BackButton"
                     Grid.Column="0"
-                    Height="32"
-                    Width="40"
                     Margin="4,0"
                     VerticalAlignment="Center"
                     AutomationProperties.Name="Back"
-                    Background="Transparent"
-                    BorderBrush="Transparent"
                     Command="{Binding ViewModel.BackCommand}"
                     IsEnabled="{Binding ViewModel.CanNavigateback}"
-                    WindowChrome.IsHitTestVisibleInChrome="True"
-                    ToolTipService.ToolTip="Back">
+                    ToolTipService.ToolTip="Back"
+                    Style="{StaticResource TitleBarDefaultButtonStyle}">
                     <Button.Resources>
                         <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="Transparent" />
                         <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Transparent" />


### PR DESCRIPTION
Removed explicit sizing, background, and border properties from the BackButton and applied the TitleBarDefaultButtonStyle for consistent appearance
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/729)