### PR TITLE
Fix Hyperlink UIA Name including control type on Text page

### DIFF
--- a/Sample Applications/WPFGallery/Views/Text/HyperlinkPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Text/HyperlinkPage.xaml
@@ -22,10 +22,10 @@
                     <controls:ControlExample
                         Margin="10"
                         HeaderText="A Hyperlink"
-                        XamlCode="&lt;TextBlock Margin=&quot;20&quot;&gt;&#10;    &lt;Hyperlink NavigateUri=&quot;https://www.microsoft.com&quot; RequestNavigate=&quot;Hyperlink_RequestNavigate&quot;&gt;&#10;        Lorem Ipsum link&#10;    &lt;/Hyperlink&gt;&#10;&lt;/TextBlock&gt;">
+                        XamlCode="&lt;TextBlock Margin=&quot;20&quot;&gt;&#10;                            &lt;Hyperlink NavigateUri=&quot;https://www.microsoft.com&quot; RequestNavigate=&quot;Hyperlink_RequestNavigate&quot;&gt;&#10;        Microsoft&#10;    &lt;/Hyperlink&gt;&#10;&lt;/TextBlock&gt;">
                         <TextBlock Margin="20">
                                 <Hyperlink NavigateUri="https://www.microsoft.com" RequestNavigate="Hyperlink_RequestNavigate">
-                                    Hyperlink
+                                    Microsoft
                                 </Hyperlink>
                         </TextBlock>
                     </controls:ControlExample>


### PR DESCRIPTION
## Summary
Fixes an accessibility issue on the **Text → Hyperlink** page in WPF Gallery. The sample `Hyperlink` used the visible text `Hyperlink`, so its UI Automation **Name** matched its **LocalizedControlType** (`hyperlink`). This violates WCAG/MAS **4.1.2 (Name, Role, Value)** and is flagged by Accessibility Insights as *"The Name property must not include the element's control type."*

## Change
- `Sample Applications/WPFGallery/Views/Text/HyperlinkPage.xaml`: change the link text from `Hyperlink` to `Microsoft` (its navigation target), so the Name is meaningful and no longer repeats the control type. The displayed `XamlCode` snippet is updated to match the live control.

## Result
- Screen readers now announce *"Microsoft, hyperlink"* instead of *"Hyperlink, hyperlink"*.
- Accessibility Insights automated check passes.

## Testing
- Built `WPFGallery.csproj` (0 errors).
- Verified in Accessibility Insights (Test tab) that the 4.1.2 failure on the Hyperlink is resolved.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/779)