### PR TITLE
Fix null Name on empty page header description (MAS 4.1.2)

### DIFF
--- a/Sample Applications/WPFGallery/Controls/PageHeader.xaml
+++ b/Sample Applications/WPFGallery/Controls/PageHeader.xaml
@@ -4,7 +4,7 @@
     xmlns:controls="clr-namespace:WPFGallery.Controls"
     xmlns:helpers="clr-namespace:WPFGallery.Helpers">
 
-    <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter"/>
+    <helpers:EmptyToVisibilityConverter x:Key="EmptyToVisibilityConverter"/>
 
     <Style TargetType="{x:Type controls:PageHeader}">
         <Setter Property="Focusable" Value="False"/>
@@ -25,10 +25,11 @@
                         </Label>
 
                         <Label
+                            AutomationProperties.Name="{Binding Description, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                             AutomationProperties.HeadingLevel="Level2"
                             KeyboardNavigation.IsTabStop="True"
                             KeyboardNavigation.TabIndex="1"
-                            Visibility="{TemplateBinding Description, Converter={StaticResource NullToVisibilityConverter}}"
+                            Visibility="{TemplateBinding Description, Converter={StaticResource EmptyToVisibilityConverter}}"
                             Focusable="True">
                             <TextBlock
                                 x:Name="DescriptionTextBlock"


### PR DESCRIPTION
**Summary**
Fixes an accessibility issue on the `Text` section's `Label` page (and many other control pages) in WPF Gallery. The shared  `PageHeader` description `Label` is a focusable tab stop, but its visibility was driven by `NullToVisibilityConverter`, which only collapses on `null` - not on an empty string. Pages whose description is "" (Label, TextBox, TextBlock, RichTextEdit, PasswordBox, and many more) therefore rendered an empty, focusable element with a null UI Automation Name. This violates WCAG/MAS 4.1.2 (Name, Role, Value) and is flagged by Accessibility Insights as "The Name property of a focusable element must not be null."

**Change**
`Sample Applications/WPFGallery/Controls/PageHeader.xaml`
 -  Switch the description `Label` visibility binding from `NullToVisibilityConverter` to the existing `EmptyToVisibilityConverter, so it collapses on null, empty, or whitespace.
 - Add `AutomationProperties.Name` bound to `Description so the description carries a meaningful Name when it is visible (mirroring the `Label`).
 - Remove the now-unused `NullToVisibilityConverter` resource declaration.

**Result**
On pages with empty description, the empty focusable element is gone. On pages with a description, the text still renders and now exposes a proper UIA `Name`. Screen readers no longer stop on an empty, unnamed element after the page title.

Testing
 - Built  WPFGallery.csproj  (0 errors).
 - Verified via a live UI Automation scan of the Label page that the flagged focusable null-Name text element is no longer present.
 - Confirmed in Accessibility Insights that the 4.1.2 failure on the `Text` pages is resolved.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/781)