### PR TITLE
Fixes text/content truncation on several Layout sample pages when viewed at reflow dimensions (400% zoom / narrow window / portrait orientation)

### DIFF
--- a/Sample Applications/WPFGallery/Views/Layout/BorderPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Layout/BorderPage.xaml
@@ -19,6 +19,12 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
+    <Page.Resources>
+        <Style TargetType="TextBlock">
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </Style>
+    </Page.Resources>
+
     <Grid x:Name="ContentPagePane" Height="Auto">
 
         <Grid.RowDefinitions>

--- a/Sample Applications/WPFGallery/Views/Layout/GridPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Layout/GridPage.xaml
@@ -10,6 +10,12 @@
       Title="GridPage"
       Foreground="{DynamicResource TextFillColorPrimaryBrush}">
 
+    <Page.Resources>
+        <Style TargetType="TextBlock">
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </Style>
+    </Page.Resources>
+
     <Grid x:Name="ContentPagePane" Height="Auto">
 
         <Grid.RowDefinitions>

--- a/Sample Applications/WPFGallery/Views/Layout/GroupBoxPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Layout/GroupBoxPage.xaml
@@ -26,7 +26,7 @@
    Header=&quot;User Information&quot; &#10;
    HorizontalAlignment=&quot;Left&quot; &#10;
    VerticalAlignment=&quot;Center&quot; &#10;
-   Width=&quot;400&quot;&gt;&#10;
+   MaxWidth=&quot;400&quot;&gt;&#10;
     &lt;StackPanel&gt;&#10;
         &lt;StackPanel Orientation=&quot;Horizontal&quot;&gt;&#10;
             &lt;TextBlock Width=&quot;100&quot; Text=&quot;Name:&quot; /&gt;&#10;
@@ -42,7 +42,7 @@
                           Header="User Information" 
                           HorizontalAlignment="Left" 
                           VerticalAlignment="Center" 
-                          Width="400">
+                          MaxWidth="400">
                             <StackPanel>
                                 <StackPanel Orientation="Horizontal">
                                     <TextBlock Width="100" Text="Name:" />

--- a/Sample Applications/WPFGallery/Views/Layout/ResizeGripPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Layout/ResizeGripPage.xaml
@@ -10,6 +10,12 @@
       Title="ResizeGripPage"
       Foreground="{DynamicResource TextFillColorPrimaryBrush}">
 
+    <Page.Resources>
+        <Style TargetType="TextBlock">
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </Style>
+    </Page.Resources>
+
     <Grid>
         <Grid x:Name="ContentPagePane" Height="Auto">
             <Grid.RowDefinitions>


### PR DESCRIPTION
Fixes text/content truncation on several Layout sample pages when viewed at reflow dimensions (400% zoom / narrow window / portrait orientation).

- Grid page: added a page-level `TextWrapping=Wrap` style so all TextBlock labels remain fully readable.
- Border page: same page-level `TextWrapping=Wrap` style so the "different thickness on each side" label wraps instead of being cut off.
- ResizeGrip page: same page-level `TextWrapping=Wrap` style so the description text wraps instead of being cut off.
- GroupBox page: changed the GroupBox `Width=400` to `MaxWidth=400` so it shrinks to fit instead of clipping the right-aligned Submit button.

Closes BUG 3019577 (Grid, reflow)
Closes BUG 3018152 (Grid, portrait)
Closes BUG 3019581 (Border, reflow)
Closes BUG 3018160 (Border, portrait)
Closes BUG 3019579 (GroupBox, reflow)
Closes BUG 3018158 (GroupBox, portrait)
Closes BUG 3017835 (ResizeGrip, portrait)