### PR TITLE
Fix screen reader announcing only button name, not associated description in WPF Gallery

### DIFF
--- a/Sample Applications/WPFGallery/Controls/HeaderTile.xaml
+++ b/Sample Applications/WPFGallery/Controls/HeaderTile.xaml
@@ -14,9 +14,14 @@
         VerticalAlignment="Stretch"
         HorizontalContentAlignment="Stretch"
         VerticalContentAlignment="Stretch"
-        AutomationProperties.Name="{Binding Title, RelativeSource={RelativeSource AncestorType=local:HeaderTile}}"
         Click="RootButton_Click"
         Padding="24">
+        <AutomationProperties.Name>
+            <MultiBinding StringFormat="{}{0}. {1}">
+                <Binding Path="Title" RelativeSource="{RelativeSource AncestorType=local:HeaderTile}" />
+                <Binding Path="Description" RelativeSource="{RelativeSource AncestorType=local:HeaderTile}" />
+            </MultiBinding>
+        </AutomationProperties.Name>
         <Button.Resources>
             <SolidColorBrush x:Key="ButtonBackground" Color="{DynamicResource AcrylicBackgroundFillColorDefault}" Opacity="0.8" />
             <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{DynamicResource AcrylicBackgroundFillColorDefault}" Opacity="0.9" />

--- a/Sample Applications/WPFGallery/Resources/Templates.xaml
+++ b/Sample Applications/WPFGallery/Resources/Templates.xaml
@@ -16,9 +16,14 @@
             Margin="7"
             Padding="20,10"
             HorizontalContentAlignment="Left"
-            AutomationProperties.Name="{Binding Title, StringFormat='{}{0}Page'}"
             Command="{Binding ViewModel.NavigateCommand, RelativeSource={RelativeSource AncestorType={x:Type Page}}}"
             CommandParameter="{Binding PageType}">
+            <AutomationProperties.Name>
+                <MultiBinding StringFormat="{}{0}Page. {1}">
+                    <Binding Path="Title" />
+                    <Binding Path="Description" />
+                </MultiBinding>
+            </AutomationProperties.Name>
             <StackPanel Orientation="Horizontal">
                 <Image Source="{Binding ImageSource}"
                         Width="50"


### PR DESCRIPTION
## Summary
Fixes AzDO 3019241 (MAS 1.3.1 accessibility). In the WPF Gallery app, Narrator announced only a navigation button's title and skipped the associated descriptive text.

## Root cause
The buttons had an explicit `AutomationProperties.Name` bound only to `Title`, which suppresses WPF's default fall-back to the child description `TextBlock`, so the description was never announced.

## Fix
Fold the `Description` into `AutomationProperties.Name` via a `MultiBinding` so Narrator announces both the title and the description:
- `Controls/HeaderTile.xaml` - the 5 featured tiles on Home (Getting started, Windows design, WPF GitHub, Code samples, Partner Center).
- `Resources/Templates.xaml` (`NavigationCardTemplate`) - the Overview/category cards reused across 13 pages.

Consistent with the previously-fixed AzDO 2064065, which also resolved announcement gaps by setting explicit `AutomationProperties.Name` values.

## Testing
- `dotnet build` succeeds (0 errors).
- Manual Narrator pass: both title and description are now announced for the home tiles and overview cards.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/783)