### PR TITLE
Fix Narrator announcing 'SL NO' instead of serial number on What's New page

### DIFF
--- a/Sample Applications/WPFGallery/ViewModels/WhatsNewPageViewModel.cs
+++ b/Sample Applications/WPFGallery/ViewModels/WhatsNewPageViewModel.cs
@@ -69,7 +69,7 @@ namespace WPFGallery.ViewModels
 
         private const string _gridShorthandSyntaxXamlUsage = """
             <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="Auto 80 *" HorizontalAlignment="Left">
-                <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold" Margin="0 0 10 0">Sl. No.</TextBlock>
+                <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold" Margin="0 0 10 0" AutomationProperties.Name="Serial Number">Sl. No.</TextBlock>
                 <TextBlock Grid.Row="0" Grid.Column="1" FontWeight="Bold">Name</TextBlock>
                 <TextBlock Grid.Row="0" Grid.Column="2" FontWeight="Bold">Description</TextBlock>
                 <TextBlock Grid.Row="1" Grid.Column="0">1</TextBlock>

--- a/Sample Applications/WPFGallery/Views/WhatsNewPage.xaml
+++ b/Sample Applications/WPFGallery/Views/WhatsNewPage.xaml
@@ -74,7 +74,7 @@
                     HeaderText="Grid Shorthand Syntax Sample"
                     XamlCode="{Binding ViewModel.GridShorthandSyntaxXamlCode}">
                         <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="Auto 80 *" HorizontalAlignment="Left">
-                            <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold" Margin="0 0 10 0">Sl. No.</TextBlock>
+                            <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold" Margin="0 0 10 0" AutomationProperties.Name="Serial Number">Sl. No.</TextBlock>
                             <TextBlock Grid.Row="0" Grid.Column="1" FontWeight="Bold">Name</TextBlock>
                             <TextBlock Grid.Row="0" Grid.Column="2" FontWeight="Bold">Description</TextBlock>
                             <TextBlock Grid.Row="1" Grid.Column="0">1</TextBlock>


### PR DESCRIPTION
Fixes the Narrator accessibility bug on the **What's New** page (AB#3019248).

### Problem
The `Sl. No.` column header in the *Grid Shorthand Syntax* sample table was announced literally by Narrator as ""SL NO"" instead of conveying a serial-number column. This violates MAS 4.1.2 (Name, Role, Value).

### Fix
Added `AutomationProperties.Name=""Serial Number""` to the header cell so screen readers announce a meaningful name, while the visible text remains `Sl. No.`. The displayed sample XAML string in the view model was updated to match.

### Validation
- `dotnet build WPFGallery.csproj` succeeds (0 errors).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/784)