### PR TITLE
Add accessible name to Control Alt Fill checkbox on Colors page

### DIFF
--- a/Sample Applications/WPFGallery/Views/DesignGuidance/FillSection.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/FillSection.xaml
@@ -96,7 +96,7 @@
             Title="Control Alt Fill"
             Background="{DynamicResource SolidBackgroundFillColorQuarternaryBrush}"
             Description="Fill used for the 'off' states of toggle controls">
-            <CheckBox Focusable="False"/>
+            <CheckBox Focusable="False" AutomationProperties.Name="Control Alt Fill"/>
         </controls:ColorPageExample>
         <Border Style="{StaticResource ColorTilesPanelStyle}" Margin="0,8"><Grid>
             <Grid.ColumnDefinitions>


### PR DESCRIPTION
## Summary
The example `CheckBox` in the **Control Alt Fill** section of the WPF Gallery **Colors** page (Design Guidance → Colors → *Fill* subpage) had no accessible name. As a result, Narrator announced only its checked state (e.g. "checkbox, checked") and not its label, violating MAS 4.1.2 (Name, Role, Value).

This adds `AutomationProperties.Name="Control Alt Fill"` so Narrator now announces "Control Alt Fill checkbox, checked".

## Repro
1. Enable Narrator (Ctrl+Win+Enter).
2. Open WPF Gallery → Design Guidance → Colors.
3. Set the page selector combo box to **Fill**.
4. In scan mode (Caps Lock+Spacebar), arrow to the checkbox in the **Control Alt Fill** section.

**Before:** Narrator reads only "checkbox, checked".
**After:** Narrator reads "Control Alt Fill checkbox, checked".

Fixes internal work item AB#3019259.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/785)