### PR TITLE
Add accessible name to C# code copy button (fix private Unicode Name)

### DIFF
--- a/Sample Applications/WPFGallery/Controls/ControlExample.xaml
+++ b/Sample Applications/WPFGallery/Controls/ControlExample.xaml
@@ -123,7 +123,7 @@
                                             Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                             Text="C#" />
 
-                                        <Button Grid.Column="1" Padding="8" Command="ApplicationCommands.Copy" CommandParameter="Copy_CSharpCode" FocusManager.IsFocusScope="True" >
+                                        <Button Grid.Column="1" Padding="8" Command="ApplicationCommands.Copy" CommandParameter="Copy_CSharpCode" FocusManager.IsFocusScope="True" ToolTipService.ToolTip="Copy to clipboard" AutomationProperties.Name="Copy C# Code" >
                                             <TextBlock FontFamily="{StaticResource SymbolThemeFontFamily}" Text="&#xE8C8;" />
                                         </Button>
                                     </Grid>


### PR DESCRIPTION
## Summary
The **C#** "Source code" copy button in ControlExample had no AutomationProperties.Name. Because the button's content is only a Segoe Fluent icon glyph ( , U+E8C8), WPF derived the button's UI Automation **Name** from that glyph, which falls in the Unicode **Private Use Area** (U+E000–U+F8FF). Accessibility Insights / screen readers flag this as a violation of **MAS 4.1.2 – Name, Role, Value**.

The sibling **XAML** copy button already sets `AutomationProperties.Name="Copy XAML Code"`; this change applies the same treatment to the C# copy button.

## Change
- Sample Applications/WPFGallery/Controls/ControlExample.xaml: added `AutomationProperties.Name="Copy C# Code"` (and a matching `Copy to clipboard` tooltip) to the C# code copy button.

## Repro (before fix)
1. Run WPF Gallery, open **Layout → ResizeGrip** (or any page with a C# code sample).
2. Expand **Source code** and inspect the second (C#) copy button with Accessibility Insights for Windows.
3. The Name property is reported in the private Unicode range.

Fixes AzDO [DevDiv#3018313](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/3018313). 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/786)