### PR TITLE
Fix low-contrast de-emphasized text in WPF Gallery under high contrast

### DIFF
--- a/Sample Applications/WPFGallery/App.xaml.cs
+++ b/Sample Applications/WPFGallery/App.xaml.cs
@@ -1,5 +1,6 @@
 using System.Configuration;
 using System.Data;
+using System.Windows;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -153,9 +154,24 @@ public partial class App : Application
 
         App app = new();
         app.InitializeComponent();
+        app.ApplyDeemphasizedTextOpacity();
         app.MainWindow = _host.Services.GetRequiredService<MainWindow>();
         app.MainWindow.Visibility = Visibility.Visible;
         app.Run();
+    }
+
+    // Dimmed text fails the 4.5:1 minimum under some high-contrast themes (e.g. Desert), so render
+    // de-emphasized text at full opacity there. DynamicResource pushes the change to every consumer.
+    private void ApplyDeemphasizedTextOpacity()
+    {
+        Resources["DeemphasizedTextOpacity"] = SystemParameters.HighContrast ? 1.0 : 0.7;
+        SystemParameters.StaticPropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(SystemParameters.HighContrast))
+            {
+                Resources["DeemphasizedTextOpacity"] = SystemParameters.HighContrast ? 1.0 : 0.7;
+            }
+        };
     }
 }
 

--- a/Sample Applications/WPFGallery/Resources/PageStyles.xaml
+++ b/Sample Applications/WPFGallery/Resources/PageStyles.xaml
@@ -16,6 +16,10 @@
     <sys:Double x:Key="TitleLargeTextBlockFontSize">40</sys:Double>
     <sys:Double x:Key="DisplayTextBlockFontSize">68</sys:Double>
 
+    <!-- Opacity for de-emphasized text; App overrides it to 1.0 under high contrast so dimmed
+         text keeps the 4.5:1 minimum (e.g. the Desert contrast theme). -->
+    <sys:Double x:Key="DeemphasizedTextOpacity">0.7</sys:Double>
+
     <Style x:Key="BaseTextBlockStyle" TargetType="TextBlock">
         <Setter Property="FontSize" Value="{StaticResource BodyTextBlockFontSize}" />
         <Setter Property="FontWeight" Value="SemiBold" />

--- a/Sample Applications/WPFGallery/Resources/Templates.xaml
+++ b/Sample Applications/WPFGallery/Resources/Templates.xaml
@@ -33,7 +33,7 @@
                         Width="240"
                         Margin="10,0,0,0"
                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                            Opacity="0.7"
+                            Opacity="{DynamicResource DeemphasizedTextOpacity}"
                         Style="{StaticResource CaptionTextBlockStyle}"
                         Text="{Binding Description}"/>
                 </StackPanel>

--- a/Sample Applications/WPFGallery/Views/Collections/ListViewPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Collections/ListViewPage.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
     This Source Code Form is subject to the terms of the MIT License.
     If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
     Copyright (C) Leszek Pomianowski and WPF UI Contributors.
@@ -104,7 +104,7 @@
                                             Grid.Column="1"
                                             Margin="12,0,0,6"
                                             Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                            Opacity="0.7"
+                                            Opacity="{DynamicResource DeemphasizedTextOpacity}"
                                             Text="{Binding Company, Mode=OneWay}" />
                                     </Grid>
                                 </DataTemplate>
@@ -115,7 +115,7 @@
                             MinWidth="120"
                             Margin="12,0,0,0"
                             VerticalAlignment="Top">
-                            <Label Foreground="{DynamicResource TextFillColorPrimaryBrush}" Opacity="0.7" Content="Selection mode" Target="{Binding ElementName=SelectionModeComboBox}" />
+                            <Label Foreground="{DynamicResource TextFillColorPrimaryBrush}" Opacity="{DynamicResource DeemphasizedTextOpacity}" Content="Selection mode" Target="{Binding ElementName=SelectionModeComboBox}" />
                             <ComboBox
                                 x:Name="SelectionModeComboBox"
                                 AutomationProperties.Name="Selection Mode"

--- a/Sample Applications/WPFGallery/Views/DesignGuidance/GeometryPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/GeometryPage.xaml
@@ -52,21 +52,21 @@
                                 <TextBlock
                                         Margin="16,0,0,0"
                                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                        Opacity="0.7"
+                                        Opacity="{DynamicResource DeemphasizedTextOpacity}"
                                         Style="{StaticResource CaptionTextBlockStyle}"
                                         Text="Corner radius" />
                                 <TextBlock
                                         Grid.Column="1"
                                         Margin="16,0,0,0"
                                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                        Opacity="0.7"
+                                        Opacity="{DynamicResource DeemphasizedTextOpacity}"
                                         Style="{StaticResource CaptionTextBlockStyle}"
                                         Text="Usage" />
                                 <TextBlock
                                         Grid.Column="2"
                                         Margin="16,0,0,0"
                                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                        Opacity="0.7"
+                                        Opacity="{DynamicResource DeemphasizedTextOpacity}"
                                         Style="{StaticResource CaptionTextBlockStyle}"
                                         Text="Style" />
                             </Grid>

--- a/Sample Applications/WPFGallery/Views/DesignGuidance/IconsPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/IconsPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page x:Class="WPFGallery.Views.IconsPage"
+<Page x:Class="WPFGallery.Views.IconsPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -22,7 +22,7 @@
             <Setter Property="MinHeight" Value="32" />
             <Setter Property="Padding" Value="0 0 0 4" />
             <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
-            <Setter Property="Opacity" Value="0.7"/>
+            <Setter Property="Opacity" Value="{DynamicResource DeemphasizedTextOpacity}"/>
             <Setter Property="Margin" Value="0,4,0,4" />
             <Setter Property="FontSize" Value="14"/>
         </Style>

--- a/Sample Applications/WPFGallery/Views/DesignGuidance/SpacingPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/SpacingPage.xaml
@@ -83,13 +83,13 @@
                                 <TextBlock
                                         Margin="16,0,0,0"
                                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                        Opacity="0.7"
+                                        Opacity="{DynamicResource DeemphasizedTextOpacity}"
                                         Style="{StaticResource CaptionTextBlockStyle}"
                                         Text="Value" />
                                 <TextBlock
                                         Grid.Column="2"
                                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                        Opacity="0.7"
+                                        Opacity="{DynamicResource DeemphasizedTextOpacity}"
                                         Style="{StaticResource CaptionTextBlockStyle}"
                                         Text="Usage" />
                             </Grid>

--- a/Sample Applications/WPFGallery/Views/DesignGuidance/TypographyPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/TypographyPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page x:Class="WPFGallery.Views.TypographyPage"
+<Page x:Class="WPFGallery.Views.TypographyPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -59,25 +59,25 @@
                             <TextBlock
                         Margin="16,0,0,0"
                         Foreground="{StaticResource TextFillColorPrimaryBrush}"
-                        Opacity="0.7"
+                        Opacity="{DynamicResource DeemphasizedTextOpacity}"
                         Style="{StaticResource CaptionTextBlockStyle}"
                         Text="Example" />
                             <TextBlock
                         Grid.Column="1"
                         Foreground="{StaticResource TextFillColorPrimaryBrush}"
-                        Opacity="0.7"
+                        Opacity="{DynamicResource DeemphasizedTextOpacity}"
                         Style="{StaticResource CaptionTextBlockStyle}"
                         Text="Variable Font" />
                             <TextBlock
                         Grid.Column="2"
                         Foreground="{StaticResource TextFillColorPrimaryBrush}"
-                        Opacity="0.7"
+                        Opacity="{DynamicResource DeemphasizedTextOpacity}"
                         Style="{StaticResource CaptionTextBlockStyle}"
                         Text="Size/Line height" />
                             <TextBlock
                         Grid.Column="3"
                         Foreground="{StaticResource TextFillColorPrimaryBrush}"
-                        Opacity="0.7"
+                        Opacity="{DynamicResource DeemphasizedTextOpacity}"
                         Style="{StaticResource CaptionTextBlockStyle}"
                         Text="Style" />
                         </Grid>

--- a/Sample Applications/WPFGallery/Views/Samples/UserDashboardPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Samples/UserDashboardPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="WPFGallery.Views.UserDashboardPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -20,7 +20,7 @@
         <helpers:EmptyToVisibilityConverter x:Key="EmptyToVisibilityConverter" />
 
         <Style TargetType="Label" x:Key="GenericLabelStyle">
-            <Setter Property="Opacity" Value="0.67"/>
+            <Setter Property="Opacity" Value="{DynamicResource DeemphasizedTextOpacity}"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
             <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
         </Style>
@@ -91,7 +91,7 @@
                                 Grid.Column="1"
                                 Margin="12,0,0,6"
                                 Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                Opacity="0.8"
+                                Opacity="{DynamicResource DeemphasizedTextOpacity}"
                                 Text="{Binding Company, Mode=OneWay}" />
                         </Grid>
                     </DataTemplate>

--- a/Sample Applications/WPFGallery/Views/SettingsPage.xaml
+++ b/Sample Applications/WPFGallery/Views/SettingsPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="WPFGallery.Views.SettingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -57,7 +57,7 @@
                                 Margin="12"
                                 Orientation="Vertical">
                                 <TextBlock Text="App theme" FontSize="14"/>
-                                <TextBlock Opacity="0.7" FontSize="12" Style="{StaticResource CaptionTextBlockStyle}">Select which app theme to display</TextBlock>
+                                <TextBlock Opacity="{DynamicResource DeemphasizedTextOpacity}" FontSize="12" Style="{StaticResource CaptionTextBlockStyle}">Select which app theme to display</TextBlock>
                             </StackPanel>
 
                         
@@ -93,7 +93,7 @@
                                 Margin="12"
                                 Orientation="Vertical">
                                 <TextBlock Text="WPF Gallery" />
-                                <TextBlock Opacity="0.7" Style="{StaticResource CaptionTextBlockStyle}">© 2025 Microsoft. All rights reserved.</TextBlock>
+                                <TextBlock Opacity="{DynamicResource DeemphasizedTextOpacity}" Style="{StaticResource CaptionTextBlockStyle}">© 2025 Microsoft. All rights reserved.</TextBlock>
                             </StackPanel>
                         </Grid>
                     </Expander.Header>

--- a/Sample Applications/WPFGallery/Views/Text/LabelPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Text/LabelPage.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
     This Source Code Form is subject to the terms of the MIT License.
     If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
     Copyright (C) Leszek Pomianowski and WPF UI Contributors.
@@ -32,7 +32,7 @@
                     Margin="10"
                     HeaderText="A simple Label."
                     XamlCode="&lt;Label Content=&quot;I am a Label.&quot; /&gt;">
-                    <Label Content="I am a Label." Foreground="{DynamicResource TextFillColorPrimaryBrush}" Opacity="0.7" />
+                    <Label Content="I am a Label." Foreground="{DynamicResource TextFillColorPrimaryBrush}" Opacity="{DynamicResource DeemphasizedTextOpacity}" />
                 </controls:ControlExample>
 
                 <controls:ControlExample
@@ -44,7 +44,7 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
-                        <Label Grid.Row="0" Content="I am a Label of the TextBox below." Foreground="{DynamicResource TextFillColorPrimaryBrush}" Opacity="0.7" />
+                        <Label Grid.Row="0" Content="I am a Label of the TextBox below." Foreground="{DynamicResource TextFillColorPrimaryBrush}" Opacity="{DynamicResource DeemphasizedTextOpacity}" />
                         <!--  Target="{Binding ElementName=TextBoxForLabel}"  -->
                         <TextBox Grid.Row="1" AutomationProperties.Name="Simple Text Box" />
                     </Grid>


### PR DESCRIPTION
**Summary**
 Fixes an accessibility issue in the WPF Gallery. De-emphasized "caption/label" text (column headers, form labels, page-button descriptions, list secondary text, settings captions) rendered below the 4.5:1 minimum required by MAS 4.3.1 under the `Desert` contrast theme,and is flagged by Accessibility Insights across multiple pages. The app dims this text by applying a hardcoded ~0.7 Opacity over the primary text brush. In normal and Aquatic themes the resulting gray passes, but Desert's WindowText / background pair is borderline, so the dimmed text drops under 4.5:1. The same pattern is used throughout the app, so the issue recurs on many pages.

**Change**
`Sample Applications/WPFGallery/Resources/PageStyles.xaml`
 Add a shared `DynamicResource`, `DeemphasizedTextOpacity` (0.7), for dimmed text.

`Sample Applications/WPFGallery/App.xaml.cs`
 Override `DeemphasizedTextOpacity` to 1.0 when `SystemParameters.HighContrast` is set, and update it live on high-contrast changes. `DynamicResource` pushes the new value to every consumer.

`Sample Applications/WPFGallery/Resources/Templates.xaml` and 8 view files
 (Typography, Icons, ListView, User Dashboard, Label, Settings, Geometry, Spacing) route their dimmed-text `Opacity` through {DynamicResource DeemphasizedTextOpacity} instead of a hardcoded literal. Because the lever is the opacity itself, the text keeps its primary brush (no color change) and looks identical in normal mode, while rendering at the theme's full `WindowText` color in any contrast theme.

**Result**
Under high contrast the de-emphasized text now renders at the theme's full `WindowText` color, comfortably above the 4.5:1 minimum, so the Accessibility Insights Text Contrast check passes. Normal Light/Dark appearance is unchanged.

**Testing**
- Built WPFGallery.csproj (0 errors).
- Verified all 7 reported pages with the accessibility tools under the `Desert` contrast theme (now > 4.5:1).
- Confirmed normal Light and Dark appearance is unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/787)