### PR TITLE
Fix keyboard scrolling on Spacing design guidance page

### DIFF
--- a/Sample Applications/WPFGallery/Views/DesignGuidance/SpacingPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/SpacingPage.xaml
@@ -17,7 +17,8 @@
 
         <controls:PageHeader Margin="0,0,0,32" Title="{Binding ViewModel.PageTitle}" Description="{Binding ViewModel.PageDescription}" />
 
-        <ScrollViewer Margin="0,0,0,24" Padding="0,0,24,0" HorizontalScrollBarVisibility="Auto" Grid.Row="1">
+        <ScrollViewer Margin="0,0,0,24" Padding="0,0,24,0" HorizontalScrollBarVisibility="Auto"
+            Focusable="True" IsTabStop="True" AutomationProperties.Name="Spacing guidance content" Grid.Row="1">
             <StackPanel Margin="0,0,0,24" Orientation="Vertical">
                 <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap">
                     Consistent spacing helps create visual harmony and improves the readability and usability of your application.


### PR DESCRIPTION
## Summary
The Spacing page (Design Guidance) could not be scrolled with the keyboard. The `ScrollViewer` was not focusable and had no tab stop, so users could not Tab to the content or use Arrow / Page Up / Page Down keys to scroll.

## Changes
- Set `Focusable=True` and `IsTabStop=True` on the SpacingPage `ScrollViewer`, so it can receive keyboard focus and be scrolled via the keyboard.
- Added `AutomationProperties.Name` for screen-reader context.

Fixes #3018621.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/789)