### PR TITLE
Fix keyboard focus not reaching DataGrid column headers

### DIFF
--- a/Sample Applications/WPFGallery/Views/Collections/DataGridPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Collections/DataGridPage.xaml
@@ -33,12 +33,18 @@
                 <controls:ControlExample
                     Margin="10"
                     HeaderText="Default DataGrid with ItemsSource."
-                    XamlCode="&lt;DataGrid ItemsSource=&quot;{Binding ViewModel.ProductsCollection, Mode=TwoWay}&quot; /&gt;">
+                    XamlCode="&lt;DataGrid ItemsSource=&quot;{Binding ViewModel.ProductsCollection, Mode=TwoWay}&quot;&gt;&#10;&#9;&lt;DataGrid.ColumnHeaderStyle&gt;&#10;&#9;&#9;&lt;Style BasedOn=&quot;{StaticResource {x:Type DataGridColumnHeader}}&quot; TargetType=&quot;DataGridColumnHeader&quot;&gt;&#10;&#9;&#9;&#9;&lt;Setter Property=&quot;Focusable&quot; Value=&quot;True&quot; /&gt;&#10;&#9;&#9;&lt;/Style&gt;&#10;&#9;&lt;/DataGrid.ColumnHeaderStyle&gt;&#10;&lt;/DataGrid&gt;">
                     <DataGrid
                         x:Name="SampleDataGrid"
                         Height="400"
                         AutomationProperties.Name="Sample Data Grid"
-                        ItemsSource="{Binding ViewModel.ProductsCollection, Mode=TwoWay}" />
+                        ItemsSource="{Binding ViewModel.ProductsCollection, Mode=TwoWay}">
+                        <DataGrid.ColumnHeaderStyle>
+                            <Style BasedOn="{StaticResource {x:Type DataGridColumnHeader}}" TargetType="DataGridColumnHeader">
+                                <Setter Property="Focusable" Value="True" />
+                            </Style>
+                        </DataGrid.ColumnHeaderStyle>
+                    </DataGrid>
                 </controls:ControlExample>
 
             </StackPanel>

--- a/Sample Applications/WPFGallery/Views/Collections/DataGridPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Collections/DataGridPage.xaml
@@ -20,6 +20,24 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
+    <Page.Resources>
+        <Style x:Key="ColumnHeaderFocusVisualStyle">
+            <Setter Property="Control.Template">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <Rectangle
+                            Margin="2"
+                            RadiusX="4"
+                            RadiusY="4"
+                            SnapsToDevicePixels="True"
+                            Stroke="{DynamicResource KeyboardFocusBorderColorBrush}"
+                            StrokeThickness="2" />
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Page.Resources>
+
     <Grid x:Name="ContentPagePane" Height="Auto">
 
         <Grid.RowDefinitions>
@@ -33,7 +51,7 @@
                 <controls:ControlExample
                     Margin="10"
                     HeaderText="Default DataGrid with ItemsSource."
-                    XamlCode="&lt;DataGrid ItemsSource=&quot;{Binding ViewModel.ProductsCollection, Mode=TwoWay}&quot;&gt;&#10;&#9;&lt;DataGrid.ColumnHeaderStyle&gt;&#10;&#9;&#9;&lt;Style BasedOn=&quot;{StaticResource {x:Type DataGridColumnHeader}}&quot; TargetType=&quot;DataGridColumnHeader&quot;&gt;&#10;&#9;&#9;&#9;&lt;Setter Property=&quot;Focusable&quot; Value=&quot;True&quot; /&gt;&#10;&#9;&#9;&lt;/Style&gt;&#10;&#9;&lt;/DataGrid.ColumnHeaderStyle&gt;&#10;&lt;/DataGrid&gt;">
+                    XamlCode="&lt;DataGrid ItemsSource=&quot;{Binding ViewModel.ProductsCollection, Mode=TwoWay}&quot;&gt;&#10;&#9;&lt;DataGrid.ColumnHeaderStyle&gt;&#10;&#9;&#9;&lt;Style BasedOn=&quot;{StaticResource {x:Type DataGridColumnHeader}}&quot; TargetType=&quot;DataGridColumnHeader&quot;&gt;&#10;&#9;&#9;&#9;&lt;Setter Property=&quot;Focusable&quot; Value=&quot;True&quot; /&gt;&#10;&#9;&#9;&#9;&lt;Setter Property=&quot;FocusVisualStyle&quot; Value=&quot;{StaticResource ColumnHeaderFocusVisualStyle}&quot; /&gt;&#10;&#9;&#9;&lt;/Style&gt;&#10;&#9;&lt;/DataGrid.ColumnHeaderStyle&gt;&#10;&lt;/DataGrid&gt;">
                     <DataGrid
                         x:Name="SampleDataGrid"
                         Height="400"
@@ -42,6 +60,7 @@
                         <DataGrid.ColumnHeaderStyle>
                             <Style BasedOn="{StaticResource {x:Type DataGridColumnHeader}}" TargetType="DataGridColumnHeader">
                                 <Setter Property="Focusable" Value="True" />
+                                <Setter Property="FocusVisualStyle" Value="{StaticResource ColumnHeaderFocusVisualStyle}" />
                             </Style>
                         </DataGrid.ColumnHeaderStyle>
                     </DataGrid>


### PR DESCRIPTION
WPF Gallery → Collections → DataGrid: while navigating with the keyboard, focus skipped the column headings, so keyboard-only users could not reach them. `DataGridColumnHeader` is non-focusable by default.

This adds a `ColumnHeaderStyle` on the sample DataGrid that sets `Focusable=True` (based on the Fluent default style), so the column headings receive keyboard focus during navigation. The displayed XamlCode is updated to match.

Testing: Navigate to Collections → DataGrid and Tab/arrow into the table - focus now lands on the column headers.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/791)