### PR TITLE
Fix editable ComboBox Shift+Tab keyboard trap in WPF Gallery (ADO 3019001)

### DIFF
--- a/Sample Applications/WPFGallery/Views/BasicInput/ComboBoxPage.xaml
+++ b/Sample Applications/WPFGallery/Views/BasicInput/ComboBoxPage.xaml
@@ -72,6 +72,7 @@
                         HorizontalAlignment="Left"
                         AutomationProperties.Name="Editable"
                         IsEditable="True"
+                        IsTabStop="False"
                         ItemsSource="{Binding ViewModel.ComboBoxFontSizes, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:ComboBoxPage}, Mode=OneWay}"
                         SelectedIndex="0" />
                 </controls:ControlExample>


### PR DESCRIPTION
### Summary
Fixes a keyboard trap on the **Basic Input -> ComboBox** page of WPF Gallery. When focus is on the editable ComboBox's edit field, pressing **Shift+Tab** does not move focus to the previous control, trapping keyboard users.

Fixes ADO 3019001.

### Root cause
The .NET Fluent theme's `DefaultComboBoxStyle` `IsEditable=True` trigger only swaps the control template - unlike the classic/Aero theme, it never sets `IsTabStop="False"` on the ComboBox. As a result, an editable ComboBox exposes **two** tab stops: the ComboBox itself *and* its inner `PART_EditableTextBox`. Shift+Tab from the edit field lands on the ComboBox container, which redirects focus back into the edit field, so focus never leaves the control. (Forward Tab happens to escape; Shift+Tab does not.)

### Fix
Set `IsTabStop="False"` on the editable ComboBox in `Views/BasicInput/ComboBoxPage.xaml`, leaving only the inner edit field as a tab stop (mirroring the classic-theme behavior). Shift+Tab now moves focus to the previous control.

### Scope / notes
- Sample-only change; one XAML file touched.
- The underlying Fluent-theme defect still affects other editable ComboBoxes and may warrant a separate upstream fix in dotnet/wpf.

### Testing
- Verified Shift+Tab from the editable ComboBox now moves focus to the previous control.
- `dotnet build` succeeds (0 errors).

### Accessibility
- MAS 2.1.1 – Keyboard / WCAG 2.1.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/794)