### PR TITLE
Fix 2D scrolling on Design Guidance pages at reflow dimensions (WCAG …

### DIFF
--- a/Sample Applications/WPFGallery/Views/DesignGuidance/GeometryPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/GeometryPage.xaml
@@ -17,7 +17,7 @@
 
         <controls:PageHeader Margin="0,0,0,32" Title="{Binding ViewModel.PageTitle}" ShowDescription="False"/>
 
-        <ScrollViewer Margin="0,0,0,24" Padding="0,0,24,0" HorizontalScrollBarVisibility="Auto" Grid.Row="1">
+        <ScrollViewer Margin="0,0,0,24" Padding="0,0,24,0" HorizontalScrollBarVisibility="Disabled" Grid.Row="1">
                 <StackPanel Margin="0,0,0,24" Orientation="Vertical">
                 <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap">
                     Geometry describes the shape, size and position of UI elements on screen. 
@@ -28,7 +28,7 @@
                 <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Margin="0,0,0,12">
                     You can reference built-in corner radii styles using: CornerRadius="{StaticResource ControlCornerRadius}" .
                 </TextBlock>
-				<Border Height="300" Width="500" HorizontalAlignment="Left">
+				<Border MaxHeight="300" MaxWidth="500" HorizontalAlignment="Left">
 					<Image x:Name="GeometryImage" Source="/Assets/Design/Geometry.dark.png" AutomationProperties.Name="Example of corner radius." />
 				</Border>
                 <controls:ControlExample
@@ -46,7 +46,7 @@
                             <Grid Margin="0,0,0,24" HorizontalAlignment="Stretch">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="148" />
-                                    <ColumnDefinition Width="400" />
+                                    <ColumnDefinition Width="2*" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock
@@ -78,7 +78,7 @@
                                 <Grid HorizontalAlignment="Stretch" MinHeight="60">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="148" />
-                                        <ColumnDefinition Width="400" />
+                                        <ColumnDefinition Width="2*" />
                                         <ColumnDefinition Width="*" />
                                     </Grid.ColumnDefinitions>
                                     <StackPanel Grid.Column="0" Orientation="Horizontal">
@@ -119,7 +119,7 @@
                                 <Grid HorizontalAlignment="Stretch" MinHeight="60">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="148" />
-                                        <ColumnDefinition Width="400" />
+                                        <ColumnDefinition Width="2*" />
                                         <ColumnDefinition Width="*" />
                                     </Grid.ColumnDefinitions>
                                     <StackPanel Grid.Column="0" Orientation="Horizontal">
@@ -160,7 +160,7 @@
                                 <Grid HorizontalAlignment="Stretch" MinHeight="60">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="148" />
-                                        <ColumnDefinition Width="400" />
+                                        <ColumnDefinition Width="2*" />
                                         <ColumnDefinition Width="*" />
                                     </Grid.ColumnDefinitions>
                                     <StackPanel Grid.Column="0" Orientation="Horizontal">

--- a/Sample Applications/WPFGallery/Views/DesignGuidance/SpacingPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/SpacingPage.xaml
@@ -17,7 +17,7 @@
 
         <controls:PageHeader Margin="0,0,0,32" Title="{Binding ViewModel.PageTitle}" Description="{Binding ViewModel.PageDescription}" />
 
-        <ScrollViewer Margin="0,0,0,24" Padding="0,0,24,0" HorizontalScrollBarVisibility="Auto"
+        <ScrollViewer Margin="0,0,0,24" Padding="0,0,24,0" HorizontalScrollBarVisibility="Disabled"
             Focusable="True" IsTabStop="True" AutomationProperties.Name="Spacing guidance content" Grid.Row="1">
             <StackPanel Margin="0,0,0,24" Orientation="Vertical">
                 <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap">
@@ -26,8 +26,8 @@
                 <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Margin="0,0,0,12">
                     Use the following spacing values to maintain a consistent layout throughout your app.
                 </TextBlock>
-                <StackPanel Margin="0,0,0,16" Orientation="Horizontal">
-                    <Grid VerticalAlignment="Top">
+                <WrapPanel Margin="0,0,0,16">
+                    <Grid VerticalAlignment="Top" MaxWidth="360" Margin="0,0,16,16">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
@@ -36,11 +36,11 @@
                         HorizontalAlignment="Center"
                         Style="{StaticResource SubtitleTextBlockStyle}"
                         Text="Page with cards layout" />
-                        <Border Grid.Row="1" Height="500">
+                        <Border Grid.Row="1" MaxHeight="500">
                             <Image x:Name="CardImage" Source="/Assets/Design/Cards.dark.png" AutomationProperties.Name="Example of spacing in a page with cards layout" />
                         </Border>
                     </Grid>
-                    <Grid VerticalAlignment="Top">
+                    <Grid VerticalAlignment="Top" MaxWidth="360" Margin="0,0,16,16">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
@@ -49,19 +49,18 @@
                         HorizontalAlignment="Center"
                         Style="{StaticResource SubtitleTextBlockStyle}"
                         Text="Form layout" />
-                        <Border Grid.Row="1" Height="500">
+                        <Border Grid.Row="1" MaxHeight="500">
                             <Image x:Name="DialogImage" Source="/Assets/Design/Dialog.dark.png" AutomationProperties.Name="Example of spacing in a form layout" />
                         </Border>
                     </Grid>
-                </StackPanel>
-                <Border
-                    Margin="0,10,0,10"
+                </WrapPanel>
+                <Border Margin="0,10,0,10"
                     Padding="16"
                     Background="{DynamicResource SolidBackgroundFillColorBaseBrush}"
                     BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1,1,1,0"
                     CornerRadius="8,8,0,0">
-                    <Grid>
+                    <Grid HorizontalAlignment="Left" MaxWidth="590">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
@@ -79,7 +78,7 @@
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="100" />
                                     <ColumnDefinition Width="100" />
-                                    <ColumnDefinition Width="400" />
+                                    <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock
                                         Margin="16,0,0,0"
@@ -102,7 +101,7 @@
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="90" />
                                     <ColumnDefinition Width="100" />
-                                    <ColumnDefinition Width="400" />
+                                    <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock
                                         Margin="16,0,0,0"
@@ -128,7 +127,7 @@
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="90" />
                                     <ColumnDefinition Width="100" />
-                                    <ColumnDefinition Width="400" />
+                                    <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock
                                         Margin="16,0,0,0"
@@ -153,7 +152,7 @@
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="90" />
                                     <ColumnDefinition Width="100" />
-                                    <ColumnDefinition Width="400" />
+                                    <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock
                                         Margin="16,0,0,0"
@@ -178,7 +177,7 @@
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="90" />
                                     <ColumnDefinition Width="100" />
-                                    <ColumnDefinition Width="400" />
+                                    <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock
                                         Margin="16,0,0,0"
@@ -203,7 +202,7 @@
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="90" />
                                     <ColumnDefinition Width="100" />
-                                    <ColumnDefinition Width="400" />
+                                    <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock
                                         Margin="16,0,0,0"
@@ -228,7 +227,7 @@
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="90" />
                                     <ColumnDefinition Width="100" />
-                                    <ColumnDefinition Width="400" />
+                                    <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock
                                         Margin="16,0,0,0"
@@ -253,7 +252,7 @@
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="90" />
                                     <ColumnDefinition Width="100" />
-                                    <ColumnDefinition Width="400" />
+                                    <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock
                                         Margin="16,0,0,0"

--- a/Sample Applications/WPFGallery/Views/DesignGuidance/TypographyPage.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/TypographyPage.xaml
@@ -17,7 +17,7 @@
 
         <controls:PageHeader Margin="0,0,0,32" Title="{Binding ViewModel.PageTitle}" Description="{Binding ViewModel.PageDescription}" />
 
-    <ScrollViewer Margin="0,0,0,24" Padding="0,0,24,0" HorizontalScrollBarVisibility="Auto" Grid.Row="1">
+    <ScrollViewer Margin="0,0,0,24" Padding="0,0,24,0" HorizontalScrollBarVisibility="Disabled" Grid.Row="1">
       <StackPanel Margin="0,0,0,24" Orientation="Vertical">
         <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" >
           Type helps provide structure and hierarchy to UI. The default font for Windows is Segoe UI Variable.</TextBlock>
@@ -37,7 +37,7 @@
                 &#10;&lt;TextBlock Text=&quot;Title&quot; Style=&quot;{StaticResource TitleTextBlockStyle}&quot; /&gt;
                 &#10;&lt;TextBlock Text=&quot;Title Large&quot; Style=&quot;{StaticResource TitleLargeTextBlockStyle}&quot; /&gt;
                 &#10;&lt;TextBlock Text=&quot;Display&quot; Style=&quot;{StaticResource DisplayTextBlockStyle}&quot; /&gt;" >
-                <Grid>
+                <Grid HorizontalAlignment="Left" MaxWidth="684">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
@@ -51,10 +51,10 @@
                     <StackPanel Grid.Row="0">
                         <Grid Margin="0,0,0,24" HorizontalAlignment="Stretch">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="272" />
-                                <ColumnDefinition Width="136" />
-                                <ColumnDefinition Width="112" />
-                                <ColumnDefinition Width="164" />
+                                <ColumnDefinition Width="272*" />
+                                <ColumnDefinition Width="136*" />
+                                <ColumnDefinition Width="112*" />
+                                <ColumnDefinition Width="164*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock
                         Margin="16,0,0,0"
@@ -85,10 +85,10 @@
                     <StackPanel Grid.Row="1">
                         <Grid HorizontalAlignment="Stretch" Background="{StaticResource CardBackgroundFillColorDefaultBrush}" MinHeight="68">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="272" />
-                                <ColumnDefinition Width="136" />
-                                <ColumnDefinition Width="112" />
-                                <ColumnDefinition Width="164" />
+                                <ColumnDefinition Width="272*" />
+                                <ColumnDefinition Width="136*" />
+                                <ColumnDefinition Width="112*" />
+                                <ColumnDefinition Width="164*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock
                         Margin="16,0,0,0"
@@ -115,10 +115,10 @@
                     <StackPanel Grid.Row="2">
                         <Grid HorizontalAlignment="Stretch" MinHeight="68">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="272" />
-                                <ColumnDefinition Width="136" />
-                                <ColumnDefinition Width="112" />
-                                <ColumnDefinition Width="164" />
+                                <ColumnDefinition Width="272*" />
+                                <ColumnDefinition Width="136*" />
+                                <ColumnDefinition Width="112*" />
+                                <ColumnDefinition Width="164*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock
                         Margin="16,0,0,0"
@@ -145,10 +145,10 @@
                     <StackPanel Grid.Row="3">
                         <Grid HorizontalAlignment="Stretch" Background="{StaticResource CardBackgroundFillColorDefaultBrush}" MinHeight="68">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="272" />
-                                <ColumnDefinition Width="136" />
-                                <ColumnDefinition Width="112" />
-                                <ColumnDefinition Width="164" />
+                                <ColumnDefinition Width="272*" />
+                                <ColumnDefinition Width="136*" />
+                                <ColumnDefinition Width="112*" />
+                                <ColumnDefinition Width="164*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock
                         Margin="16,0,0,0"
@@ -175,10 +175,10 @@
                     <StackPanel Grid.Row="4">
                         <Grid HorizontalAlignment="Stretch" MinHeight="68">
                             <Grid.ColumnDefinitions> 
-                                <ColumnDefinition Width="272" />
-                                <ColumnDefinition Width="136" />
-                                <ColumnDefinition Width="112" />
-                                <ColumnDefinition Width="164" />
+                                <ColumnDefinition Width="272*" />
+                                <ColumnDefinition Width="136*" />
+                                <ColumnDefinition Width="112*" />
+                                <ColumnDefinition Width="164*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock
                         Margin="16,0,0,0"
@@ -205,10 +205,10 @@
                     <StackPanel Grid.Row="5">
                         <Grid Margin="0,0,0,24" HorizontalAlignment="Stretch" Background="{StaticResource CardBackgroundFillColorDefaultBrush}" MinHeight="68">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="272" />
-                                <ColumnDefinition Width="136" />
-                                <ColumnDefinition Width="112" />
-                                <ColumnDefinition Width="164" />
+                                <ColumnDefinition Width="272*" />
+                                <ColumnDefinition Width="136*" />
+                                <ColumnDefinition Width="112*" />
+                                <ColumnDefinition Width="164*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock
                         Margin="16,0,0,0"
@@ -235,10 +235,10 @@
                     <StackPanel Grid.Row="6">
                         <Grid Margin="0,0,0,24" HorizontalAlignment="Stretch" MinHeight="68">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="272" />
-                                <ColumnDefinition Width="136" />
-                                <ColumnDefinition Width="112" />
-                                <ColumnDefinition Width="164" />
+                                <ColumnDefinition Width="272*" />
+                                <ColumnDefinition Width="136*" />
+                                <ColumnDefinition Width="112*" />
+                                <ColumnDefinition Width="164*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock
                         Margin="16,0,0,0"
@@ -265,10 +265,10 @@
                     <StackPanel Grid.Row="7">
                         <Grid Margin="0,0,0,24" HorizontalAlignment="Stretch" Background="{StaticResource CardBackgroundFillColorDefaultBrush}" MinHeight="68">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="272" />
-                                <ColumnDefinition Width="136" />
-                                <ColumnDefinition Width="112" />
-                                <ColumnDefinition Width="164" />
+                                <ColumnDefinition Width="272*" />
+                                <ColumnDefinition Width="136*" />
+                                <ColumnDefinition Width="112*" />
+                                <ColumnDefinition Width="164*" />
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <TextBlock


### PR DESCRIPTION
**Summary**
Fixes an accessibility issue in the WPF Gallery Design Guidance pages. On the Typography, Spacing, and Geometry pages, both a horizontal and a vertical scrollbar appear at reflow dimensions, so users must scroll in two directions to reach all content. This fails WCAG 2.1 SC 1.4.10 (Reflow) / MAS 1.4.10, which requires content to be usable without scrolling in two dimensions, and is a physical-challenge trap (Trap 2.1) for low-vision and motor-impaired users. The cause is that each page's reference table uses fixed-width Grid  columns and the example images use fixed sizes, forcing content wider than the viewport inside a `ScrollViewer` with `HorizontalScrollBarVisibility="Auto"`.

Change
`Sample Applications/WPFGallery/Views/DesignGuidance/TypographyPage.xaml`
Disable horizontal scrolling on the `ScrollViewer`. Convert the type-ramp table's fixed column widths to proportional star widths so the table reflows, and cap it with `MaxWidth` (left-aligned) so the normal wide-window appearance is unchanged.

`Sample Applications/WPFGallery/Views/DesignGuidance/SpacingPage.xaml`
Disable horizontal scrolling. Star-size the spacing table's usage column and cap the table with `MaxWidth`. Change the two side-by-side example images from a horizontal `StackPanel` to a `WrapPanel` with bounded, scalable cards so they scale down and stack vertically when the window is narrow.

`Sample Applications/WPFGallery/Views/DesignGuidance/GeometryPage.xaml`
Disable horizontal scrolling. Star-size the corner-radius table's usage column and make the example image responsive so it scales down instead of forcing width.

Result
At reflow dimensions the three pages now present a single vertical scrollbar; the tables' columns compress and their text wraps, and the images scale down (and stack, on Spacing), so all content is reachable without horizontal scrolling. At normal window sizes the layout and proportions are unchanged.

Testing
- Built WPFGallery.csproj (0 errors).
- Verified the Typography, Spacing, and Geometry pages at reflow dimensions (nav pane collapsed, narrow window): only the vertical scrollbar is shown, and no content is clipped or lost.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/795)