### PR TITLE
Fix Listview names for the narrator

### DIFF
--- a/Sample Applications/WPFGallery/Views/Collections/ListViewPage.xaml
+++ b/Sample Applications/WPFGallery/Views/Collections/ListViewPage.xaml
@@ -49,6 +49,11 @@
                         ItemsSource="{Binding ViewModel.BasicListViewItems, Mode=TwoWay}"
                         SelectedIndex="2"
                         SelectionMode="Single">
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem">
+                                <Setter Property="AutomationProperties.Name" Value="{Binding Name, Mode=OneWay}" />
+                            </Style>
+                        </ListView.ItemContainerStyle>
                         <ListView.ItemTemplate>
                             <DataTemplate DataType="{x:Type models:Person}">
                                 <TextBlock Margin="8,4" Text="{Binding Name, Mode=OneWay}" />


### PR DESCRIPTION
**Summary**
Fixes an accessibility issue on the WPF Gallery Collections ListView page. In the first example, the item template renders only the person's Name, but Narrator also announces extra, unnecessary information, including the Company - flagged under MAS 1.3.1 - Info and Relationships and Trap 1.4 - Uncomprehended Element.

**Change**
`Sample Applications/WPFGallery/Views/Collections/ListViewPage.xaml`
Added an `ItemContainerStyle` on the first `ListView` that sets `AutomationProperties.Name="{Binding Name, Mode=OneWay}"` on each `ListViewItem`. An explicit accessible name on the container takes precedence over the  ToString() fallback, so the item's name matches its visible content. Scoped to this example only; the other examples on the page are unchanged.

**Result**
Under Narrator scan mode, each item in the Basic ListView now announces only the person's name, matching what is displayed on screen. The leaked record fields (including Company) are no longer announced, satisfying MAS 1.3.1. Visual appearance is unchanged.

**Testing**
- Built WPFGallery.csproj (0 errors).
- Verified with a screen reader that the Basic ListView items announce only the Name, with no extra field/company information.