### PR TITLE
Populate empty DataGrid Quantity per Unit column

### DIFF
--- a/Sample Applications/WPFGallery/ViewModels/Collections/DataGridPageViewModel.cs
+++ b/Sample Applications/WPFGallery/ViewModels/Collections/DataGridPageViewModel.cs
@@ -30,6 +30,7 @@ public partial class DataGridPageViewModel : ObservableObject
 
         var adjectives = new[] { "Red", "Blueberry" };
         var names = new[] { "Marmalade", "Dumplings", "Soup" };
+        var quantitiesPerUnit = new[] { "6", "10", "12", "16", "24", "48" };
         //var units = new[] { "grams", "kilograms", "milliliters" };
 
         for (int i = 0; i < 50; i++)
@@ -43,6 +44,7 @@ public partial class DataGridPageViewModel : ObservableObject
                         adjectives[random.Next(0, adjectives.Length)]
                         + " "
                         + names[random.Next(0, names.Length)],
+                    QuantityPerUnit = quantitiesPerUnit[random.Next(0, quantitiesPerUnit.Length)],
                     UnitPrice = Math.Round(random.NextDouble() * 20.0, 3),
                     UnitsInStock = random.Next(0, 100)
                 }


### PR DESCRIPTION
**Summary**

Fixes an accessibility issue on the WPF Gallery Collections DataGrid page. The Quantity per Unit column is completely empty, and when focus lands on one of its cells Narrator announces meaningless internal information instead of an empty value - flagged under MAS 1.3.1 - Info and Relationships and Trap 1.4 - Uncomprehended Element.

**Change**

`Sample Applications/WPFGallery/ViewModels/Collections/DataGridPageViewModel.cs`
Populated `QuantityPerUnit` with realistic values, assigned randomly using the same generation pattern already used for the other product fields. The column now contains meaningful data, so no cell is empty.

**Result**

Focusing a Quantity per Unit cell now announces the actual cell value instead of the internal type-name fallback string, satisfying MAS 1.3.1. The sample data is also more complete and realistic. No XAML or visual/layout changes.

**Testing**

• Built WPFGallery.csproj (0 errors).
• Verified with a screen reader that Quantity per Unit cells announce their populated value
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/797)