### PR TITLE
Fix WPF Gallery navigation text overlapping scrollbar at 200% text scaling

### DIFF
--- a/Sample Applications/WPFGallery/MainWindow.xaml
+++ b/Sample Applications/WPFGallery/MainWindow.xaml
@@ -221,7 +221,7 @@
                         Loaded="ControlsList_Loaded">
                         <TreeView.ItemTemplate>
                             <HierarchicalDataTemplate ItemsSource="{Binding Items}">
-                                <Grid MinHeight="30">
+                                <Grid MinHeight="30" Margin="0,0,16,0">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto" />
                                         <ColumnDefinition Width="16" />


### PR DESCRIPTION
## Problem
In WPF Gallery, navigation pane labels (e.g. "File and Folder Dialogs") overlap the vertical scrollbar when Windows text scaling is set to 200%. Fixes ADO 3017671.

## Cause
The Fluent theme's vertical scrollbar is a 12px overlay drawn on top of the content's right edge. The auto-sized nav pane grows to fit each item's text, but the overlay scrollbar still covers the last characters of the widest label - made worse at 200%.

## Fix
Reserve 16px of right-side space on the nav item content in `MainWindow.xaml` so the pane accounts for the scrollbar and the overlay covers the margin instead of the text.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/799)