### PR TITLE
Fix clipped Rectangle text in What's New Grid shorthand sample

### DIFF
--- a/Sample Applications/WPFGallery/Views/WhatsNewPage.xaml
+++ b/Sample Applications/WPFGallery/Views/WhatsNewPage.xaml
@@ -73,12 +73,12 @@
                     Margin="2 10 2 24"
                     HeaderText="Grid Shorthand Syntax Sample"
                     XamlCode="{Binding ViewModel.GridShorthandSyntaxXamlCode}">
-                        <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="Auto 80 *" HorizontalAlignment="Left">
+                        <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="Auto Auto *" HorizontalAlignment="Left">
                             <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold" Margin="0 0 10 0" AutomationProperties.Name="Serial Number">Sl. No.</TextBlock>
                             <TextBlock Grid.Row="0" Grid.Column="1" FontWeight="Bold">Name</TextBlock>
                             <TextBlock Grid.Row="0" Grid.Column="2" FontWeight="Bold">Description</TextBlock>
                             <TextBlock Grid.Row="1" Grid.Column="0">1</TextBlock>
-                            <TextBlock Grid.Row="1" Grid.Column="1">Rectangle</TextBlock>
+                            <TextBlock Grid.Row="1" Grid.Column="1" Margin="0 0 10 0">Rectangle</TextBlock>
                             <TextBlock Grid.Row="1" Grid.Column="2" TextWrapping="Wrap">Quadrilateral where all the adjacent sides form a right angle.</TextBlock>
                             <TextBlock Grid.Row="2" Grid.Column="0">2</TextBlock>
                             <TextBlock Grid.Row="2" Grid.Column="1">Circle</TextBlock>


### PR DESCRIPTION
Fixes ADO #3017677.

The "Name" column in the Grid Shorthand Syntax sample on the What's New page used a fixed width of 80px, which clipped the word "Rectangle" depending on font/DPI. Changed the column to Auto so it sizes to its content and added a right margin to the cell for spacing before the Description column.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/800)