### PR TITLE
Fix keyboard focus not scrolling copy buttons into view on Color and Icons pages

### DIFF
--- a/Sample Applications/WPFGallery/Controls/ColorTile.xaml
+++ b/Sample Applications/WPFGallery/Controls/ColorTile.xaml
@@ -56,7 +56,6 @@
                                     Foreground="{TemplateBinding Foreground}"
                                     Command="ApplicationCommands.Copy"
                                     CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type controls:ColorTile}}}"
-                                    FocusManager.IsFocusScope="True"
                                     ToolTipService.ToolTip="Copy brush name">
                                     <Grid>
                                         <TextBlock x:Name="CopyGlyphTextBlock" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="16" Text="&#xE8C8;" />

--- a/Sample Applications/WPFGallery/Controls/IconDataField.xaml
+++ b/Sample Applications/WPFGallery/Controls/IconDataField.xaml
@@ -29,7 +29,6 @@
 
         <Button Grid.Column="1"
                 Padding="8"
-                FocusManager.IsFocusScope="True"
                 Click="CopyButton_Click"
                 AutomationProperties.Name="{Binding Label, ElementName=Root, StringFormat='{}Copy {0} to clipboard'}"
                 ToolTipService.ToolTip="Copy to clipboard">


### PR DESCRIPTION
## Summary

Removes `FocusManager.IsFocusScope="True"` from the copy buttons in **ColorTile** (Design Guidance → Color) and **IconDataField** (Design Guidance → Icons).

The stray focus scope split *logical* focus from *keyboard* focus, so tabbing to a copy button that was scrolled out of view did **not** raise the framework's `IsKeyboardFocused → BringIntoView` path. The button received focus but stayed off-screen — a WCAG 2.4.3 / 2.4.7 (focus order / focus visible) issue. Work item: AB#3036673.

## Why `IsFocusScope` was safe to remove

It was never needed on these buttons:

- **ColorTile** routes `ApplicationCommands.Copy` via an explicit `CommandTarget` + a class `CommandBinding`, so command routing is focus-independent. `IsFocusScope` was originally added in #564 as plumbing for a *target-less* Copy command, and made redundant by the explicit `CommandTarget` added in #583 — it was simply never cleaned up.
- **IconDataField** copies via a `Click` handler (`CopyButton_Click`), which does not depend on focus at all.

## Result

- Tab now scrolls the focused copy button into view on both pages.
- Copy-to-clipboard continues to work (verified on both pages).

`ControlExample`'s source-code copy buttons are intentionally left unchanged — their tab/scroll behavior is already correct.

## Testing

- Design Guidance → Color: Tab through copy buttons; off-screen buttons scroll into view; brush name still copies.
- Design Guidance → Icons: same behavior verified; icon text still copies.
- Build: `dotnet build WPFGallery.csproj` succeeds (0 errors).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/802)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/802)