### PR TITLE
Fix WPF Gallery User Dashboard new-user date defaulting to 0001-01-01

### DIFF
--- a/Sample Applications/WPFGallery/ViewModels/Samples/UserDashboardPageViewModel.cs
+++ b/Sample Applications/WPFGallery/ViewModels/Samples/UserDashboardPageViewModel.cs
@@ -38,7 +38,7 @@ namespace WPFGallery.ViewModels.Samples
         [RelayCommand]
         private void AddUser()
         {
-            Users.Add(new User("New User", ""));
+            Users.Add(new User("New User", "") { DateOfJoining = DateTime.Today });
             SelectedUser = Users.Last();
            
             IsReadOnly = false;


### PR DESCRIPTION
Fixes #3019508

## Problem
In the WPF Gallery **Samples -> User Dashboard** sample, clicking **Add New User** created a user whose **Date of Joining** was left uninitialized. `AddUser()` used the `User(firstName, lastName)` constructor, which never sets `DateOfJoining`, so it fell back to `default(DateTime)` = `DateTime.MinValue` (**0001-01-01**).

This invalid value caused a downstream accessibility issue: because WPF's `DatePicker` round-trips its value through the current culture's date format, a 2-digit-year locale renders year `0001` as `01`, which Narrator reads incorrectly ("O-O-O-1") and which re-parses to `2001` when the calendar is opened. On 4-digit-year locales it showed `0001`. Both are wrong.

## Fix
Initialize `DateOfJoining` to `DateTime.Today` when adding a new user:

```csharp
Users.Add(new User("New User", "") { DateOfJoining = DateTime.Today });
```

A valid, current date has an unambiguous century, so it displays and is announced correctly regardless of regional date-format settings - no framework change needed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/803)