### PR TITLE
fix(color): Allowing controls to get focus

### DIFF
--- a/Sample Applications/WPFGallery/Views/DesignGuidance/FillSection.xaml
+++ b/Sample Applications/WPFGallery/Views/DesignGuidance/FillSection.xaml
@@ -96,7 +96,7 @@
             Title="Control Alt Fill"
             Background="{DynamicResource SolidBackgroundFillColorQuarternaryBrush}"
             Description="Fill used for the 'off' states of toggle controls">
-            <CheckBox Focusable="False" AutomationProperties.Name="Control Alt Fill"/>
+            <CheckBox AutomationProperties.Name="Control Alt Fill"/>
         </controls:ColorPageExample>
         <Border Style="{StaticResource ColorTilesPanelStyle}" Margin="0,8"><Grid>
             <Grid.ColumnDefinitions>
@@ -156,7 +156,6 @@
             Background="{DynamicResource SolidBackgroundFillColorQuarternaryBrush}"
             Description="Fills used for Sliders thumb control to cover the track beneath it.">
             <Slider
-                Focusable="False"
                 MinWidth="240"
                 Maximum="100"
                 Value="40" />
@@ -183,7 +182,6 @@
             Background="{DynamicResource SolidBackgroundFillColorQuarternaryBrush}"
             Description="Used for controls that must meet contrast ratio requirements of 3:1.">
             <ScrollBar
-                Focusable="False"
                 Width="200"
                 Height="20"
                 Orientation="Horizontal"


### PR DESCRIPTION
Problem:
Several controls on the 'DesignGuidance > Color> Fill section' view were not allowed to receive focus.

FIx:
Removing `Focusable=False` for those controls.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/WPF-Samples/pull/804)